### PR TITLE
ignore kube-vip not found error

### DIFF
--- a/pkg/controller/ippool/kubevip/kubevip.go
+++ b/pkg/controller/ippool/kubevip/kubevip.go
@@ -95,9 +95,12 @@ func (c *IPPoolConverter) ConvertFromKubevipConfigMap() ([]*lbv1.IPPool, error) 
 // AfterConversion will add the annotation into kubevip configmap to tag that the conversion is done.
 func (c *IPPoolConverter) AfterConversion() error {
 	cm, err := c.cmClient.Get(kubeSystemNamespace, kubevipIPPoolConfigMap, metav1.GetOptions{})
-	if err != nil {
+	if apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
 		return err
 	}
+
 	if cm.Annotations != nil && cm.Annotations[keyAfterConversion] == utils.ValueTrue {
 		return nil
 	}


### PR DESCRIPTION
resolve the error below 
```
p:/home/rancher # kubectl logs -f -nharvester-system harvester-load-balancer-698bd68d66-prqbd
I0522 11:45:52.803143       1 leaderelection.go:248] attempting to acquire leader lease kube-system/harvester-load-balancer...
I0522 11:45:52.910730       1 leaderelection.go:258] successfully acquired lease kube-system/harvester-load-balancer
time="2023-05-22T11:45:52Z" level=info msg="Initialize IP pool from kube-vip configmap"
time="2023-05-22T11:45:52Z" level=fatal msg="error register ip pool controller: initialize from kubevip configmap failed, configmaps \"kubevip\" not found"
```

related issue: https://github.com/harvester/harvester/issues/1580

