### PR TITLE
Record the allocated IPs to allocated history during upgrading

### DIFF
--- a/pkg/controller/ippool/kubevip/kubevip.go
+++ b/pkg/controller/ippool/kubevip/kubevip.go
@@ -284,10 +284,10 @@ func (c *IPPoolConverter) assignAllocatedIPs(cm *corev1.ConfigMap, pool *lbv1.IP
 		// assign the IP to the pool, if it is not in the pool, try to assign to GlobalIPPoolName IP pool
 		if pool != nil && len(rangeSet) > 0 && rangeSet.Contains(ip) {
 			logrus.Infof("ip %s in the pool %s", ip, pool.Name)
-			pool.Status.Allocated[service.VIP] = cm.Namespace + "/" + service.ServiceName
+			pool.Status.AllocatedHistory[service.VIP] = cm.Namespace + "/" + service.ServiceName
 		} else if c.GlobalIPPoolNamePool != nil && c.GlobalIPPoolNameRangeSet != nil && c.GlobalIPPoolNameRangeSet.Contains(ip) {
 			logrus.Infof("ip %s in the global pool", ip)
-			c.GlobalIPPoolNamePool.Status.Allocated[service.VIP] = cm.Namespace + "/" + service.ServiceName
+			c.GlobalIPPoolNamePool.Status.AllocatedHistory[service.VIP] = cm.Namespace + "/" + service.ServiceName
 		}
 	}
 
@@ -318,7 +318,7 @@ func makeIPPool(name string, ranges []lbv1.Range) *lbv1.IPPool {
 			Selector: selector,
 		},
 		Status: lbv1.IPPoolStatus{
-			Allocated: make(map[string]string),
+			AllocatedHistory: make(map[string]string),
 		},
 	}
 

--- a/pkg/controller/ippool/kubevip/testdata/case1/ippool.yaml
+++ b/pkg/controller/ippool/kubevip/testdata/case1/ippool.yaml
@@ -11,7 +11,7 @@ spec:
         project: "*"
         guestCluster: "*"
 status:
-  allocated:
+  allocatedHistory:
     192.168.10.73: default/svc1
 ---
 apiVersion: loadbalancer.harvesterhci.io/v1beta1
@@ -28,7 +28,7 @@ spec:
         project: "*"
         guestCluster: "*"
 status:
-    allocated:
+    allocatedHistory:
       192.168.20.73: ns1/svc2
       192.168.30.2: ns1/svc3
 ---
@@ -50,6 +50,6 @@ spec:
         project: "*"
         guestCluster: "*"
 status:
-  allocated:
+  allocatedHistory:
     192.168.40.7: ns-2/svc4
     192.168.50.15: ns-2/svc5

--- a/pkg/controller/ippool/kubevip/testdata/case2/ippool.yaml
+++ b/pkg/controller/ippool/kubevip/testdata/case2/ippool.yaml
@@ -11,7 +11,7 @@ spec:
       project: "*"
       guestCluster: "*"
 status:
-  allocated:
+  allocatedHistory:
     192.168.0.162: default/lb1
 ---
 apiVersion: loadbalancer.harvesterhci.io/v1beta1
@@ -27,6 +27,6 @@ spec:
         project: "*"
         guestCluster: "*"
 status:
-  allocated:
+  allocatedHistory:
     192.168.10.73: default/lb2
 

--- a/pkg/controller/ippool/kubevip/testdata/case3/ippool.yaml
+++ b/pkg/controller/ippool/kubevip/testdata/case3/ippool.yaml
@@ -11,7 +11,7 @@ spec:
       project: "*"
       guestCluster: "*"
 status:
-  allocated:
+  allocatedHistory:
     192.168.0.162: default/lb1
     192.168.0.16: harvester-system/lb3
 ---
@@ -28,6 +28,6 @@ spec:
         project: "*"
         guestCluster: "*"
 status:
-  allocated:
+  allocatedHistory:
     192.168.10.73: default/lb2
 


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/4329

Solution:
Convert the allocated IPs of the kube-vip IP pools to the field `status.allocatedHistory` of the IP pool instead of the field `status.allocated`.

Test cases:
Refer to the reproduction steps in issue 4329.