### PR TITLE
Ignore global IP pool during matching Lb requirements

### DIFF
--- a/pkg/ipam/selector.go
+++ b/pkg/ipam/selector.go
@@ -63,6 +63,7 @@ func (s *Selector) Select(r *Requirement) (*lbv1.IPPool, error) {
 	for _, pool := range pools {
 		if pool.Labels != nil && pool.Labels[utils.KeyGlobalIPPool] == utils.ValueTrue {
 			globalPool = pool
+			continue
 		}
 		// If the priority is not zero, every pool has different priority value.
 		if NewMatcher(pool.Spec.Selector).Matches(r) && pool.Spec.Selector.Priority >= priority {

--- a/pkg/ipam/selector_test.go
+++ b/pkg/ipam/selector_test.go
@@ -1,0 +1,71 @@
+package ipam
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/harvester/harvester-load-balancer/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/harvester-load-balancer/pkg/utils"
+	"github.com/harvester/harvester-load-balancer/pkg/utils/fakeclients"
+)
+
+const rootDir = "./testdata/selector/"
+
+func TestSelector_Select(t *testing.T) {
+	cases, err := utils.GetSubdirectories(rootDir)
+	if err != nil {
+		t.Error(err)
+	}
+
+	testcases := []struct {
+		Requirement  *Requirement
+		ExpectedPool string
+		wantErr      bool
+	}{
+		{
+			Requirement: &Requirement{
+				Namespace: "default",
+			},
+			ExpectedPool: "default",
+		},
+		{
+			Requirement: &Requirement{
+				Namespace: "test",
+			},
+			ExpectedPool: "global",
+		},
+		{
+			Requirement: &Requirement{
+				Network:   "default/vlan10",
+				Project:   "project1",
+				Namespace: "default",
+				Cluster:   "cluster1",
+			},
+			ExpectedPool: "default-vlan10",
+		},
+		{
+			Requirement: &Requirement{
+				Namespace: "default",
+			},
+			ExpectedPool: "default-priority100",
+		},
+	}
+
+	for i, c := range cases {
+		t.Logf("test %s", c)
+
+		objs, err := utils.ParseFromFile(filepath.Join(rootDir, c, "ippool.yaml"))
+		if err != nil {
+			t.Errorf("test %s failed, error: %v", c, err)
+		}
+		lbClientset := fake.NewSimpleClientset(objs...)
+		selector := NewSelector(fakeclients.IPPoolCache(lbClientset.LoadbalancerV1beta1().IPPools))
+		pool, err := selector.Select(testcases[i].Requirement)
+		if err != nil {
+			t.Errorf("test %s failed, error: %v", c, err)
+		}
+		if pool.Name != testcases[i].ExpectedPool {
+			t.Errorf("test %s failed, expected: %s, got: %s", c, testcases[i].ExpectedPool, pool.Name)
+		}
+	}
+}

--- a/pkg/ipam/testdata/selector/case1/ippool.yaml
+++ b/pkg/ipam/testdata/selector/case1/ippool.yaml
@@ -1,0 +1,31 @@
+apiVersion: loadbalancer.harvesterhci.io/v1beta1
+kind: IPPool
+metadata:
+  labels:
+    loadbalancer.harvesterhci.io/global-ip-pool: "false"
+    loadbalancer.harvesterhci.io/vid: "0"
+  name: default
+spec:
+  ranges:
+    - subnet: 172.19.110.192/27
+  selector:
+    scope:
+      - guestCluster: '*'
+        namespace: default
+        project: '*'
+---
+apiVersion: loadbalancer.harvesterhci.io/v1beta1
+kind: IPPool
+metadata:
+  labels:
+    loadbalancer.harvesterhci.io/global-ip-pool: "true"
+    loadbalancer.harvesterhci.io/vid: "0"
+  name: global
+spec:
+  ranges:
+    - subnet: 172.19.111.192/27
+  selector:
+    scope:
+      - guestCluster: '*'
+        namespace: '*'
+        project: '*'

--- a/pkg/ipam/testdata/selector/case2/ippool.yaml
+++ b/pkg/ipam/testdata/selector/case2/ippool.yaml
@@ -1,0 +1,31 @@
+apiVersion: loadbalancer.harvesterhci.io/v1beta1
+kind: IPPool
+metadata:
+  labels:
+    loadbalancer.harvesterhci.io/global-ip-pool: "false"
+    loadbalancer.harvesterhci.io/vid: "0"
+  name: default
+spec:
+  ranges:
+    - subnet: 172.19.110.192/27
+  selector:
+    scope:
+      - guestCluster: '*'
+        namespace: default
+        project: '*'
+---
+apiVersion: loadbalancer.harvesterhci.io/v1beta1
+kind: IPPool
+metadata:
+  labels:
+    loadbalancer.harvesterhci.io/global-ip-pool: "true"
+    loadbalancer.harvesterhci.io/vid: "0"
+  name: global
+spec:
+  ranges:
+    - subnet: 172.19.111.192/27
+  selector:
+    scope:
+      - guestCluster: '*'
+        namespace: '*'
+        project: '*'

--- a/pkg/ipam/testdata/selector/case3/ippool.yaml
+++ b/pkg/ipam/testdata/selector/case3/ippool.yaml
@@ -1,0 +1,27 @@
+apiVersion: loadbalancer.harvesterhci.io/v1beta1
+kind: IPPool
+metadata:
+  name: default-vlan10
+spec:
+  ranges:
+    - subnet: 172.19.110.192/27
+  selector:
+    network: default/vlan10
+    scope:
+      - guestCluster: cluster1
+        namespace: default
+        project: project1
+---
+apiVersion: loadbalancer.harvesterhci.io/v1beta1
+kind: IPPool
+metadata:
+  name: default-vlan20
+spec:
+  ranges:
+    - subnet: 172.19.110.192/27
+  selector:
+    network: default/vlan20
+    scope:
+      - guestCluster: cluster1
+        namespace: default
+        project: project1

--- a/pkg/ipam/testdata/selector/case4/ippool.yaml
+++ b/pkg/ipam/testdata/selector/case4/ippool.yaml
@@ -1,0 +1,26 @@
+apiVersion: loadbalancer.harvesterhci.io/v1beta1
+kind: IPPool
+metadata:
+  name: default
+spec:
+  ranges:
+    - subnet: 172.19.110.192/27
+  selector:
+    scope:
+      - guestCluster: '*'
+        namespace: default
+        project: '*'
+---
+apiVersion: loadbalancer.harvesterhci.io/v1beta1
+kind: IPPool
+metadata:
+  name: default-priority100
+spec:
+  ranges:
+    - subnet: 172.19.110.192/27
+  selector:
+    priority: 100
+    scope:
+      - guestCluster: '*'
+        namespace: default
+        project: '*'

--- a/pkg/lb/servicelb/manager.go
+++ b/pkg/lb/servicelb/manager.go
@@ -206,7 +206,7 @@ func (m *Manager) RemoveBackendServers(lb *lbv1.LoadBalancer, servers []pkglb.Ba
 		return false, nil
 	}
 
-	indexes := make([]int, 0)
+	indexes := make([]int, 0, len(servers))
 	for _, server := range servers {
 		flag, index, err := isExisting(eps, server)
 		if err != nil || !flag {
@@ -220,7 +220,7 @@ func (m *Manager) RemoveBackendServers(lb *lbv1.LoadBalancer, servers []pkglb.Ba
 	}
 
 	epsCopy := eps.DeepCopy()
-	epsCopy.Endpoints = make([]discoveryv1.Endpoint, 0)
+	epsCopy.Endpoints = make([]discoveryv1.Endpoint, 0, len(eps.Endpoints))
 	preIndex := -1
 	for _, index := range indexes {
 		epsCopy.Endpoints = append(epsCopy.Endpoints, eps.Endpoints[preIndex+1:index]...)
@@ -499,7 +499,7 @@ func (m *Manager) constructEndpointSlice(cur *discoveryv1.EndpointSlice, lb *lbv
 	}
 	eps.Endpoints = endpoints
 
-	logrus.Infoln("constructEndpointSlice: ", eps)
+	logrus.Debugln("constructEndpointSlice: ", eps)
 
 	return eps, nil
 }

--- a/pkg/webhook/loadbalancer/testdata/converter/case1/loadbalancer.yaml
+++ b/pkg/webhook/loadbalancer/testdata/converter/case1/loadbalancer.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   ipam: pool
-  ipPool: default
+  ipPool: pool1
   listeners:
     - backendPort: 30131
       name: a
@@ -51,7 +51,7 @@ status:
     - 172.19.105.122
   allocatedAddress:
     ip: 192.168.0.100
-    ipPool: default
+    ipPool: pool1
   address: 192.168.0.100
   conditions:
     - lastUpdateTime: '2023-03-20T12:26:45Z'

--- a/pkg/webhook/loadbalancer/testdata/converter/pool.yaml
+++ b/pkg/webhook/loadbalancer/testdata/converter/pool.yaml
@@ -1,7 +1,7 @@
 apiVersion: loadbalancer.harvesterhci.io/v1beta1
 kind: IPPool
 metadata:
-  name: default
+  name: pool1
 spec:
   ranges:
     - subnet: 192.168.0.0/24
@@ -17,4 +17,25 @@ status:
       status: "True"
       type: Ready
   lastAllocated: 192.168.0.100
+  total: 253
+---
+apiVersion: loadbalancer.harvesterhci.io/v1beta1
+kind: IPPool
+metadata:
+  name: pool2
+spec:
+  ranges:
+    - subnet: 192.168.1.0/24
+  selector:
+    scope:
+      - namespace: default
+status:
+  allocated:
+    192.168.1.100: default/lb2
+  available: 252
+  conditions:
+    - lastUpdateTime: "2023-03-30T09:36:01Z"
+      status: "True"
+      type: Ready
+  lastAllocated: 192.168.1.100
   total: 253


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/4372

Solution:
- ignore global IP pool during matching LB requirements
- Change the way to find the pool when converting LB from v1alpha1 to v1beta1

Test plan:
- Spin up Harvester v1.2.0-rc4 and an RKE2 guest cluster in `default` namespace with Harvester cloud provider 0.1.14.
- Create two IP pools as below.
```
apiVersion: loadbalancer.harvesterhci.io/v1beta1
kind: IPPool
metadata:
  name: default
spec:
  ranges:
  - subnet: 172.19.110.192/27
  selector:
    scope:
    - guestCluster: '*'
      namespace: default
      project: '*'
---
apiVersion: loadbalancer.harvesterhci.io/v1beta1
kind: IPPool
metadata:
  name: global
spec:
  ranges:
  - subnet: 172.19.111.192/27
  selector:
    scope:
    - guestCluster: '*'
      namespace: '*'
      project: '*'
```
- Create a svc with pool IPAM mode in the guest cluster. Check the LB status.