### PR TITLE
feat: bump SLE to 15.5

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.suse.com/bci/bci-minimal:15.4
+FROM registry.suse.com/bci/bci-minimal:15.5
 COPY bin/harvester-load-balancer /usr/bin/
 CMD ["harvester-load-balancer"]

--- a/package/Dockerfile.webhook
+++ b/package/Dockerfile.webhook
@@ -1,3 +1,3 @@
-FROM registry.suse.com/bci/bci-minimal:15.4
+FROM registry.suse.com/bci/bci-minimal:15.5
 COPY bin/harvester-load-balancer-webhook /usr/bin/
 CMD ["harvester-load-balancer-webhook"]


### PR DESCRIPTION
**Problem:**
SLE 15 SP4 general ends on 31 Dec 2023.

**Solution:**
Bump SLE BCI images to to 15.5.

**Related Issue:**
https://github.com/harvester/harvester/issues/4757

**Test plan:**
Test basic operation can work.
