### PR TITLE
fix: Spelling On Error Message About Range

### DIFF
--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -63,7 +63,7 @@ func NewAllocator(name string, ranges []lbv1.Range, cache ctllbv1.IPPoolCache, c
 func MakeRange(r *lbv1.Range) (*allocator.Range, error) {
 	ip, ipNet, err := net.ParseCIDR(r.Subnet)
 	if err != nil {
-		return nil, fmt.Errorf("invalide range %+v", r)
+		return nil, fmt.Errorf("invalid range %+v", r)
 	}
 
 	var defaultStart, defaultEnd, defaultGateway, start, end, gateway net.IP


### PR DESCRIPTION
* fixes small spelling error on the error message concerning the range being invalid for an IP Pool that will bubble back up to the admission webhook on the Harvester Dashboard front-end

Resolves: fix/spelling-on-error-msg
See also: https://github.com/harvester/harvester/issues/5358