### PR TITLE
fix: explicitly specify the name of the copied binary

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -11,5 +11,5 @@ RUN if [ "$TARGETPLATFORM" != "linux/amd64" ] && [ "$TARGETPLATFORM" != "linux/a
 
 ENV ARCH=${TARGETPLATFORM#linux/}
 
-COPY bin/harvester-load-balancer-${ARCH} /usr/bin/
+COPY bin/harvester-load-balancer-${ARCH} /usr/bin/harvester-load-balancer
 CMD ["harvester-load-balancer"]

--- a/package/Dockerfile.webhook
+++ b/package/Dockerfile.webhook
@@ -11,5 +11,5 @@ RUN if [ "$TARGETPLATFORM" != "linux/amd64" ] && [ "$TARGETPLATFORM" != "linux/a
 
 ENV ARCH=${TARGETPLATFORM#linux/}
 
-COPY bin/harvester-load-balancer-webhook-${ARCH} /usr/bin/
+COPY bin/harvester-load-balancer-webhook-${ARCH} /usr/bin/harvester-load-balancer-webhook
 CMD ["harvester-load-balancer-webhook"]


### PR DESCRIPTION
This is follow-up fix for an uncaught error for the CI migration work #29.

Need to specify the copy destination file name to avoid the the file-not-found issue for binaries built for different architecture.