### PR TITLE
Refactor LB

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -115,7 +115,7 @@ func run(ctx context.Context, cfg *rest.Config, options *config.Options) error {
 	webhookServer := server.NewWebhookServer(ctx, cfg, name, options)
 
 	if err := webhookServer.RegisterValidators(ippool.NewIPPoolValidator(poolCache),
-		loadbalancer.NewValidator(vmiCache)); err != nil {
+		loadbalancer.NewValidator()); err != nil {
 		return fmt.Errorf("failed to register ip pool validator: %w", err)
 	}
 

--- a/pkg/controller/ippool/controller.go
+++ b/pkg/controller/ippool/controller.go
@@ -81,11 +81,8 @@ func (h *Handler) OnRemove(_ string, ipPool *lbv1.IPPool) (*lbv1.IPPool, error) 
 	if ipPool == nil {
 		return nil, nil
 	}
-
-	logrus.Debugf("IP Pool %s has been deleted", ipPool.Name)
-
+	logrus.Infof("IP Pool %s is deleted", ipPool.Name)
 	h.allocatorMap.Delete(ipPool.Name)
-
 	return ipPool, nil
 }
 

--- a/pkg/controller/loadbalancer/controller.go
+++ b/pkg/controller/loadbalancer/controller.go
@@ -2,6 +2,7 @@ package loadbalancer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -29,12 +30,17 @@ const (
 	AnnotationKeyProject   = lb.GroupName + "/project"
 	AnnotationKeyNamespace = lb.GroupName + "/namespace"
 	AnnotationKeyCluster   = lb.GroupName + "/cluster"
+)
 
-	defaultWaitIPTimeout = time.Second * 5
+var (
+	errNoMatchedIPPool             = errors.New("no matched IPPool")
+	errNoAvailableIP               = errors.New("no available IP")
+	errNoRunningBackendServer      = errors.New("no running backend servers")
+	errAllBackendServersNotHealthy = errors.New("running backend servers are not probed as healthy")
 )
 
 type Handler struct {
-	lbClient            ctllbv1.LoadBalancerClient
+	lbController        ctllbv1.LoadBalancerController
 	ipPoolCache         ctllbv1.IPPoolCache
 	nadCache            ctlcniv1.NetworkAttachmentDefinitionCache
 	serviceClient       ctlcorev1.ServiceClient
@@ -49,7 +55,7 @@ type Handler struct {
 }
 
 func Register(ctx context.Context, management *config.Management) error {
-	lbs := management.LbFactory.Loadbalancer().V1beta1().LoadBalancer()
+	lbc := management.LbFactory.Loadbalancer().V1beta1().LoadBalancer()
 	pools := management.LbFactory.Loadbalancer().V1beta1().IPPool()
 	nads := management.CniFactory.K8s().V1().NetworkAttachmentDefinition()
 	services := management.CoreFactory.Core().V1().Service()
@@ -57,7 +63,7 @@ func Register(ctx context.Context, management *config.Management) error {
 	vmis := management.KubevirtFactory.Kubevirt().V1().VirtualMachineInstance()
 
 	handler := &Handler{
-		lbClient:            lbs,
+		lbController:        lbc,
 		ipPoolCache:         pools.Cache(),
 		nadCache:            nads.Cache(),
 		serviceClient:       services,
@@ -71,8 +77,14 @@ func Register(ctx context.Context, management *config.Management) error {
 		lbManager: management.LBManager,
 	}
 
-	lbs.OnChange(ctx, controllerName, handler.OnChange)
-	lbs.OnRemove(ctx, controllerName, handler.OnRemove)
+	// NOTE: register the health check hander BEFORE the controller starts working
+	// no mutex is used to protect
+	if err := handler.lbManager.RegisterHealthCheckHandler(handler.HealthCheckNotify); err != nil {
+		return err
+	}
+
+	lbc.OnChange(ctx, controllerName, handler.OnChange)
+	lbc.OnRemove(ctx, controllerName, handler.OnRemove)
 
 	return nil
 }
@@ -81,43 +93,118 @@ func (h *Handler) OnChange(_ string, lb *lbv1.LoadBalancer) (*lbv1.LoadBalancer,
 	if lb == nil || lb.DeletionTimestamp != nil || lb.APIVersion != lbv1.SchemeGroupVersion.String() {
 		return nil, nil
 	}
-	logrus.Debugf("load balancer %s/%s has been changed, spec: %+v, apiVersion: %s", lb.Namespace, lb.Name, lb.Spec, lb.APIVersion)
+	logrus.Debugf("lb %s/%s is changed, spec: %+v, apiVersion: %s", lb.Namespace, lb.Name, lb.Spec, lb.APIVersion)
 
 	lbCopy := lb.DeepCopy()
-	allocatedAddress, err := h.allocateIP(lb)
-	if err != nil {
-		err = fmt.Errorf("allocate ip for lb %s/%s failed, error: %w", lb.Namespace, lb.Name, err)
-		return h.updateStatus(lbCopy, lb, err)
+
+	// 1. ensure lb get an address
+	if lb, err := h.ensureAllocatedAddress(lbCopy, lb); err != nil {
+		return h.handleError(lbCopy, lb, err)
 	}
-	if allocatedAddress != nil {
-		lbCopy.Status.AllocatedAddress = *allocatedAddress
-	}
+
+	// 2. ensure lb's implementation when it is VM type
 	// The workload type defaults to VM if not specified to be compatible with previous versions
 	if lb.Spec.WorkloadType == lbv1.VM || lb.Spec.WorkloadType == "" {
-		if err = h.ensureVMLoadBalancer(lbCopy); err != nil {
-			return h.updateStatus(lbCopy, lb, err)
+		if lb, err := h.ensureVMLoadBalancer(lbCopy, lb); err != nil {
+			return h.handleError(lbCopy, lb, err)
 		}
 	}
 
+	// move lb to Ready
 	return h.updateStatus(lbCopy, lb, nil)
 }
 
-func (h *Handler) ensureVMLoadBalancer(lb *lbv1.LoadBalancer) error {
-	if err := h.lbManager.EnsureLoadBalancer(lb); err != nil {
-		return fmt.Errorf("ensure load balancer %s/%s failed, error: %w", lb.Namespace, lb.Name, err)
+func (h *Handler) OnRemove(_ string, lb *lbv1.LoadBalancer) (*lbv1.LoadBalancer, error) {
+	if lb == nil {
+		return nil, nil
 	}
-	ip, err := h.waitServiceExternalIP(lb.Namespace, lb.Name)
-	if err != nil {
-		return fmt.Errorf("wait service %s/%s external ip failed, error: %w", lb.Namespace, lb.Name, err)
-	}
-	lb.Status.Address = ip
-	servers, err := h.getBackendServers(lb)
-	if err != nil {
-		return fmt.Errorf("get backend servers of lb %s/%s failed, error: %w", lb.Namespace, lb.Name, err)
-	}
-	lb.Status.BackendServers = servers
+	logrus.Infof("lb %s/%s is deleted, address %s, allocatedIP %s", lb.Namespace, lb.Name, lb.Status.Address, lb.Status.AllocatedAddress.IP)
 
-	return nil
+	if lb.Spec.IPAM == lbv1.Pool && lb.Status.AllocatedAddress.IPPool != "" {
+		if err := h.releaseIP(lb); err != nil {
+			logrus.Infof("lb %s/%s fail to release ip %s, error: %s", lb.Namespace, lb.Name, lb.Status.AllocatedAddress.IP, err.Error())
+			return nil, fmt.Errorf("fail to release ip %s, error: %w", lb.Status.AllocatedAddress.IP, err)
+		}
+		logrus.Debugf("lb %s/%s release ip %s", lb.Namespace, lb.Name, lb.Status.AllocatedAddress.IP)
+	}
+
+	if lb.Spec.WorkloadType == lbv1.VM || lb.Spec.WorkloadType == "" {
+		if err := h.lbManager.DeleteLoadBalancer(lb); err != nil {
+			logrus.Infof("lb %s/%s fail to delete service, error: %s", lb.Namespace, lb.Name, err.Error())
+			return nil, fmt.Errorf("fail to delete service, error: %w", err)
+		}
+		logrus.Debugf("lb %s/%s delete service", lb.Namespace, lb.Name)
+	}
+
+	return lb, nil
+}
+
+func (h *Handler) handleError(lbCopy, lb *lbv1.LoadBalancer, err error) (*lbv1.LoadBalancer, error) {
+	// handle customized error
+	if errors.Is(err, errNoMatchedIPPool) || errors.Is(err, errNoAvailableIP) || errors.Is(err, lbpkg.ErrWaitExternalIP) {
+		h.lbController.EnqueueAfter(lb.Namespace, lb.Name, 1*time.Second)
+		return h.updateStatusNotReturnError(lbCopy, lb, err)
+	} else if errors.Is(err, errNoRunningBackendServer) || errors.Is(err, errAllBackendServersNotHealthy) {
+		// stop reconciler, wait vmi controller Enqueue() lb / health check go thread Enqueue()
+		return h.updateStatusNotReturnError(lbCopy, lb, err)
+	}
+	return h.updateStatus(lbCopy, lb, err)
+}
+
+func (h *Handler) ensureAllocatedAddress(lbCopy, lb *lbv1.LoadBalancer) (*lbv1.LoadBalancer, error) {
+	if lb.Spec.IPAM == lbv1.DHCP {
+		return h.ensureAllocatedAddressDHCP(lbCopy, lb)
+	}
+	return h.ensureAllocatedAddressPool(lbCopy, lb)
+}
+
+func (h *Handler) ensureVMLoadBalancer(lbCopy, lb *lbv1.LoadBalancer) (*lbv1.LoadBalancer, error) {
+	if err := h.lbManager.EnsureLoadBalancer(lb); err != nil {
+		return lb, err
+	}
+
+	ip, err := h.lbManager.EnsureLoadBalancerServiceIP(lb)
+	if err != nil {
+		lbCopy.Status.Address = ""
+		return lb, err
+	}
+
+	lbCopy.Status.Address = ip
+	servers, err := h.lbManager.EnsureBackendServers(lb)
+	if err != nil {
+		return lb, err
+	}
+	lbCopy.Status.BackendServers = getServerAddress(servers)
+	if len(lbCopy.Status.BackendServers) == 0 {
+		return lb, errNoRunningBackendServer
+	}
+
+	if lb.Spec.HealthCheck != nil && lb.Spec.HealthCheck.Port != 0 {
+		count, err := h.lbManager.GetProbeReadyBackendServerCount(lb)
+		if err != nil {
+			return lb, err
+		}
+
+		logrus.Debugf("lb %s/%s active probe count %v", lb.Namespace, lb.Name, count)
+		if count == 0 {
+			return lb, fmt.Errorf("%w total:%v, healthy:0", errAllBackendServersNotHealthy, len(lbCopy.Status.BackendServers))
+		}
+	}
+
+	return lb, nil
+}
+
+func getServerAddress(servers []lbpkg.BackendServer) []string {
+	if len(servers) == 0 {
+		return nil
+	}
+	address := make([]string, 0, len(servers))
+	for _, server := range servers {
+		if addr, ok := server.GetAddress(); ok {
+			address = append(address, addr)
+		}
+	}
+	return address
 }
 
 func (h *Handler) updateStatus(lbCopy, lb *lbv1.LoadBalancer, err error) (*lbv1.LoadBalancer, error) {
@@ -129,116 +216,98 @@ func (h *Handler) updateStatus(lbCopy, lb *lbv1.LoadBalancer, err error) (*lbv1.
 		lbv1.LoadBalancerReady.Message(lbCopy, "")
 	}
 
-	// status didn't change, don't update it
+	// don't update when no change happens
 	if reflect.DeepEqual(lbCopy.Status, lb.Status) {
 		return lbCopy, err
 	}
-
-	updatedLb, updatedErr := h.lbClient.Update(lbCopy)
+	updatedLb, updatedErr := h.lbController.Update(lbCopy)
 	if updatedErr != nil {
-		return nil, fmt.Errorf("update lb %s/%s status failed, error: %w", lb.Namespace, lb.Name, updatedErr)
+		return nil, fmt.Errorf("fail to update status, error: %w", updatedErr)
 	}
 
 	return updatedLb, err
 }
 
-func (h *Handler) getBackendServers(lb *lbv1.LoadBalancer) ([]string, error) {
-	backendServers, err := h.lbManager.GetBackendServers(lb)
-	if err != nil {
-		return nil, err
+// do not return error to wrangler framework, avoid endless error message
+// caller decides where to add Enqueue
+func (h *Handler) updateStatusNotReturnError(lbCopy, lb *lbv1.LoadBalancer, err error) (*lbv1.LoadBalancer, error) {
+	// set status to False
+	lbv1.LoadBalancerReady.False(lbCopy)
+	lbv1.LoadBalancerReady.Message(lbCopy, err.Error())
+
+	// don't update when no change happens
+	if reflect.DeepEqual(lbCopy.Status, lb.Status) {
+		return lb, nil
 	}
 
-	servers := make([]string, 0, len(backendServers))
-	for _, server := range backendServers {
-		addr, ok := server.GetAddress()
-		if ok {
-			servers = append(servers, addr)
-		}
+	updatedLb, updatedErr := h.lbController.Update(lbCopy)
+	if updatedErr != nil {
+		return nil, fmt.Errorf("fail to update status with original error %w, new error: %w", err, updatedErr)
 	}
-
-	return servers, nil
+	logrus.Infof("lb %s/%s is set to not ready, error: %s", lb.Namespace, lb.Name, err.Error())
+	return updatedLb, nil
 }
 
-func (h *Handler) OnRemove(_ string, lb *lbv1.LoadBalancer) (*lbv1.LoadBalancer, error) {
-	if lb == nil {
-		return nil, nil
-	}
-
-	logrus.Debugf("load balancer %s/%s has been deleted", lb.Namespace, lb.Name)
-
-	if lb.Spec.IPAM == lbv1.Pool && lb.Status.AllocatedAddress.IPPool != "" {
-		if err := h.releaseIP(lb); err != nil {
-			return nil, fmt.Errorf("release ip of lb %s/%s failed, error: %w", lb.Namespace, lb.Name, err)
+func (h *Handler) ensureAllocatedAddressDHCP(lbCopy, lb *lbv1.LoadBalancer) (*lbv1.LoadBalancer, error) {
+	if lb.Status.AllocatedAddress.IP != utils.Address4AskDHCP {
+		lbCopy.Status.AllocatedAddress = lbv1.AllocatedAddress{
+			IP: utils.Address4AskDHCP,
 		}
-	}
-
-	if lb.Spec.WorkloadType == lbv1.VM {
-		if err := h.lbManager.DeleteLoadBalancer(lb); err != nil {
-			return nil, fmt.Errorf("delete lb %s/%s failed, error: %w", lb.Namespace, lb.Name, err)
-		}
+		return lb, nil
 	}
 
 	return lb, nil
 }
 
-func (h *Handler) allocateIP(lb *lbv1.LoadBalancer) (*lbv1.AllocatedAddress, error) {
-	allocated := lb.Status.AllocatedAddress
-
-	if lb.Spec.IPAM == lbv1.DHCP {
-		return h.allocatedIPFromDHCP(&allocated, lb)
-	}
-
-	return h.allocatedIPFromPool(&allocated, lb)
-}
-
-func (h *Handler) allocatedIPFromDHCP(allocated *lbv1.AllocatedAddress, lb *lbv1.LoadBalancer) (*lbv1.AllocatedAddress, error) {
-	var err error
-	// release the IP if the lb has applied an IP
-	if allocated.IPPool != "" {
-		if err = h.releaseIP(lb); err != nil {
-			return nil, err
+func (h *Handler) ensureAllocatedAddressPool(lbCopy, lb *lbv1.LoadBalancer) (*lbv1.LoadBalancer, error) {
+	// lb's ip pool changes, release the previous allocated IP
+	if lb.Spec.IPPool != "" && lb.Status.AllocatedAddress.IPPool != "" && lb.Status.AllocatedAddress.IPPool != lb.Spec.IPPool {
+		logrus.Infof("lb %s/%s release ip %s to pool %s", lb.Namespace, lb.Name, lb.Status.AllocatedAddress.IP, lb.Status.AllocatedAddress.IPPool)
+		if err := h.releaseIP(lb); err != nil {
+			logrus.Warnf("lb %s/%s fail to release ip %s to pool %s, error: %s", lb.Namespace, lb.Name, lb.Status.AllocatedAddress.IP, lb.Spec.IPPool, err.Error())
+			return lb, fmt.Errorf("fail to release ip %s to pool %s, error: %w", lb.Status.AllocatedAddress.IP, lb.Spec.IPPool, err)
 		}
+
+		lbCopy.Status.AllocatedAddress = lbv1.AllocatedAddress{}
+		return lb, nil
 	}
 
-	if allocated.IP != utils.Address4AskDHCP {
-		return &lbv1.AllocatedAddress{
-			IP: utils.Address4AskDHCP,
-		}, nil
+	// allocate or re-allocate IP
+	if lb.Status.AllocatedAddress.IPPool == "" {
+		ip, err := h.allocateIPFromPool(lb)
+		if err != nil {
+			logrus.Debugf("lb %s/%s fail to allocate from pool %s", lb.Namespace, lb.Name, err.Error())
+			return lb, err
+		}
+
+		lbCopy.Status.AllocatedAddress = *ip
+		logrus.Infof("lb %s/%s allocate ip %s from pool %s", lb.Namespace, lb.Name, ip.IP, ip.IPPool)
+		return lb, nil
 	}
 
-	return nil, nil
+	return lb, nil
 }
 
-func (h *Handler) allocatedIPFromPool(allocated *lbv1.AllocatedAddress, lb *lbv1.LoadBalancer) (*lbv1.AllocatedAddress, error) {
-	var err error
+func (h *Handler) allocateIPFromPool(lb *lbv1.LoadBalancer) (*lbv1.AllocatedAddress, error) {
 	pool := lb.Spec.IPPool
 	if pool == "" {
 		// match an IP pool automatically if not specified
-		pool, err = h.selectIPPool(lb)
+		pool, err := h.selectIPPool(lb)
 		if err != nil {
-			return nil, fmt.Errorf("fail to select the pool for lb %s/%s, error: %w", lb.Namespace, lb.Name, err)
-		}
-	}
-	// release the IP from other IP pool
-	if allocated.IPPool != "" && allocated.IPPool != pool {
-		if err = h.releaseIP(lb); err != nil {
 			return nil, err
 		}
-	}
-	if allocated.IPPool != pool {
 		return h.requestIP(lb, pool)
 	}
 
-	return nil, nil
+	return h.requestIP(lb, pool)
 }
 
 func (h *Handler) requestIP(lb *lbv1.LoadBalancer, pool string) (*lbv1.AllocatedAddress, error) {
-	// get allocator
 	allocator := h.allocatorMap.Get(pool)
 	if allocator == nil {
-		return nil, fmt.Errorf("could not get the allocator %s", pool)
+		return nil, fmt.Errorf("fail to get allocator %s", pool)
 	}
-	// get IP
+	// the ip is booked on pool when successfully Get()
 	ipConfig, err := allocator.Get(fmt.Sprintf("%s/%s", lb.Namespace, lb.Name))
 	if err != nil {
 		return nil, err
@@ -264,42 +333,26 @@ func (h *Handler) selectIPPool(lb *lbv1.LoadBalancer) (string, error) {
 	}
 	pool, err := ipam.NewSelector(h.ipPoolCache).Select(r)
 	if err != nil {
-		return "", fmt.Errorf("select IP pool failed, error: %w", err)
+		return "", fmt.Errorf("%w with selector, error: %w", errNoMatchedIPPool, err)
 	}
 	if pool == nil {
-		return "", fmt.Errorf("no matching IP pool with requirement %+v", r)
+		return "", fmt.Errorf("%w with requirement %+v", errNoMatchedIPPool, r)
 	}
 
 	return pool.Name, nil
 }
 
 func (h *Handler) releaseIP(lb *lbv1.LoadBalancer) error {
+	// if pool is not ready, just fail and wait
 	a := h.allocatorMap.Get(lb.Status.AllocatedAddress.IPPool)
 	if a == nil {
-		return fmt.Errorf("could not get the allocator %s", lb.Status.AllocatedAddress.IPPool)
+		return fmt.Errorf("fail to get allocator %s", lb.Status.AllocatedAddress.IPPool)
 	}
 	return a.Release(fmt.Sprintf("%s/%s", lb.Namespace, lb.Name), "")
 }
 
-func (h *Handler) waitServiceExternalIP(namespace, name string) (string, error) {
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-	tick := ticker.C
-	timeout := time.After(defaultWaitIPTimeout)
-
-	for {
-		select {
-		case <-timeout:
-			return "", fmt.Errorf("timeout")
-		case <-tick:
-			svc, err := h.serviceCache.Get(namespace, name)
-			if err != nil {
-				logrus.Warnf("get service %s/%s failed, error: %v, continue...", namespace, name, err)
-				continue
-			}
-			if len(svc.Status.LoadBalancer.Ingress) > 0 {
-				return svc.Status.LoadBalancer.Ingress[0].IP, nil
-			}
-		}
-	}
+// lb manager health check notify that the health of some VMs changed
+func (h *Handler) HealthCheckNotify(namespace, name string) error {
+	h.lbController.Enqueue(namespace, name)
+	return nil
 }

--- a/pkg/controller/vmi/controller.go
+++ b/pkg/controller/vmi/controller.go
@@ -11,8 +11,6 @@ import (
 	lbv1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester-load-balancer/pkg/config"
 	ctllbv1 "github.com/harvester/harvester-load-balancer/pkg/generated/controllers/loadbalancer.harvesterhci.io/v1beta1"
-	lbpkg "github.com/harvester/harvester-load-balancer/pkg/lb"
-	"github.com/harvester/harvester-load-balancer/pkg/lb/servicelb"
 	"github.com/harvester/harvester-load-balancer/pkg/utils"
 )
 
@@ -22,8 +20,6 @@ type Handler struct {
 	lbController ctllbv1.LoadBalancerController
 	lbClient     ctllbv1.LoadBalancerClient
 	lbCache      ctllbv1.LoadBalancerCache
-
-	lbManager lbpkg.Manager
 }
 
 func Register(ctx context.Context, management *config.Management) error {
@@ -34,8 +30,6 @@ func Register(ctx context.Context, management *config.Management) error {
 		lbController: lbs,
 		lbClient:     lbs,
 		lbCache:      lbs.Cache(),
-
-		lbManager: management.LBManager,
 	}
 
 	vmis.OnChange(ctx, controllerName, handler.OnChange)
@@ -48,77 +42,39 @@ func (h *Handler) OnChange(_ string, vmi *kubevirtv1.VirtualMachineInstance) (*k
 	if vmi == nil || vmi.DeletionTimestamp != nil {
 		return nil, nil
 	}
-	logrus.Debugf("VMI %s/%s has been changed", vmi.Namespace, vmi.Name)
-
-	lbs, err := h.lbCache.List(vmi.Namespace, labels.Everything())
-	if err != nil {
-		return nil, fmt.Errorf("list load balancers failed, error: %w", err)
-	}
-
-	for _, lb := range lbs {
-		// skip the cluster LB or the LB whose server selector is empty
-		if lb.Spec.WorkloadType == lbv1.Cluster || len(lb.Spec.BackendServerSelector) == 0 {
-			continue
-		}
-
-		selector, err := utils.NewSelector(lb.Spec.BackendServerSelector)
-		if err != nil {
-			return nil, fmt.Errorf("parse selector %+v failed, error: %w", lb.Spec.BackendServerSelector, err)
-		}
-		// add or update the backend server to the matched load balancer
-		isChanged := false
-		if selector.Matches(labels.Set(vmi.Labels)) {
-			if isChanged, err = h.addServerToLB(vmi, lb); err != nil {
-				return nil, fmt.Errorf("add server %s/%s to lb %s/%s failed, error: %w", vmi.Namespace, vmi.Name, lb.Namespace, lb.Name, err)
-			}
-		} else { // remove the backend server from the unmatched load balancer
-			if isChanged, err = h.removeServerFromLB(vmi, lb); err != nil {
-				return nil, fmt.Errorf("remove server %s/%s from lb %s/%s failed, error: %w", vmi.Namespace, vmi.Name, lb.Namespace, lb.Name, err)
-			}
-		}
-		// update the load balancer status
-		if isChanged {
-			h.lbController.Enqueue(lb.Namespace, lb.Name)
-		}
-	}
-
-	return vmi, nil
+	logrus.Debugf("VMI %s/%s is changed", vmi.Namespace, vmi.Name)
+	return h.notifyLoadBalancer(vmi)
 }
 
 func (h *Handler) OnRemove(_ string, vmi *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
 	if vmi == nil {
 		return nil, nil
 	}
+	logrus.Debugf("VMI %s/%s is deleted", vmi.Namespace, vmi.Name)
+	return h.notifyLoadBalancer(vmi)
+}
 
-	logrus.Debugf("VMI %s/%s has been deleted", vmi.Namespace, vmi.Name)
-
-	lbs, err := h.lbCache.List("", labels.Everything())
+func (h *Handler) notifyLoadBalancer(vmi *kubevirtv1.VirtualMachineInstance) (*kubevirtv1.VirtualMachineInstance, error) {
+	lbs, err := h.lbCache.List(vmi.Namespace, labels.Everything())
 	if err != nil {
-		return nil, fmt.Errorf("list load balancers failed, error: %w", err)
+		return nil, fmt.Errorf("fail to list load balancers, error: %w", err)
 	}
 
 	for _, lb := range lbs {
 		// skip the cluster LB or the LB whose server selector is empty
-		if lb.Spec.WorkloadType == lbv1.Cluster || len(lb.Spec.BackendServerSelector) == 0 {
+		if lb.DeletionTimestamp != nil || lb.Spec.WorkloadType == lbv1.Cluster || len(lb.Spec.BackendServerSelector) == 0 {
 			continue
 		}
-		// remove the backend server from the load balancers
-		if ok, err := h.removeServerFromLB(vmi, lb); err != nil {
-			return nil, fmt.Errorf("remove server %s/%s from lb %s/%s failed, error: %w", vmi.Namespace, vmi.Name, lb.Namespace, lb.Name, err)
-		} else if ok {
+		// notify LB
+		selector, err := utils.NewSelector(lb.Spec.BackendServerSelector)
+		if err != nil {
+			return nil, fmt.Errorf("fail to parse selector %+v, error: %w", lb.Spec.BackendServerSelector, err)
+		}
+
+		if selector.Matches(labels.Set(vmi.Labels)) {
+			logrus.Debugf("VMI %s/%s notify lb %s/%s", vmi.Namespace, vmi.Name, lb.Namespace, lb.Name)
 			h.lbController.Enqueue(lb.Namespace, lb.Name)
 		}
 	}
-
 	return vmi, nil
-}
-
-func (h *Handler) removeServerFromLB(vmi *kubevirtv1.VirtualMachineInstance, lb *lbv1.LoadBalancer) (bool, error) {
-	server := &servicelb.Server{VirtualMachineInstance: vmi}
-	return h.lbManager.RemoveBackendServers(lb, []lbpkg.BackendServer{server})
-}
-
-func (h *Handler) addServerToLB(vmi *kubevirtv1.VirtualMachineInstance, lb *lbv1.LoadBalancer) (bool, error) {
-	server := &servicelb.Server{VirtualMachineInstance: vmi}
-	return h.lbManager.AddBackendServers(lb, []lbpkg.BackendServer{server})
 }

--- a/pkg/ipam/store/fake_store.go
+++ b/pkg/ipam/store/fake_store.go
@@ -69,12 +69,14 @@ func (f *FakeStore) Release(ip net.IP) error {
 	}
 
 	ipStr := ip.String()
-	if f.pool.Status.AllocatedHistory == nil {
-		f.pool.Status.AllocatedHistory = make(map[string]string)
+	if _, ok := f.pool.Status.Allocated[ipStr]; ok {
+		if f.pool.Status.AllocatedHistory == nil {
+			f.pool.Status.AllocatedHistory = make(map[string]string)
+		}
+		f.pool.Status.AllocatedHistory[ipStr] = f.pool.Status.Allocated[ipStr]
+		delete(f.pool.Status.Allocated, ipStr)
+		f.pool.Status.Available++
 	}
-	f.pool.Status.AllocatedHistory[ipStr] = f.pool.Status.Allocated[ipStr]
-	delete(f.pool.Status.Allocated, ipStr)
-	f.pool.Status.Available++
 
 	return nil
 }
@@ -92,6 +94,7 @@ func (f *FakeStore) ReleaseByID(applicantID, _ string) error {
 			f.pool.Status.AllocatedHistory[ip] = applicant
 			delete(f.pool.Status.Allocated, ip)
 			f.pool.Status.Available++
+			break
 		}
 	}
 

--- a/pkg/lb/interface.go
+++ b/pkg/lb/interface.go
@@ -1,19 +1,34 @@
 package lb
 
 import (
+	"errors"
+
 	"k8s.io/apimachinery/pkg/types"
 
 	lbv1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
 )
 
+type HealthCheckHandler func(namespace, name string) error
+
 type Manager interface {
+	// Step 1. Ensure loadbalancer
 	EnsureLoadBalancer(lb *lbv1.LoadBalancer) error
 	DeleteLoadBalancer(lb *lbv1.LoadBalancer) error
-	GetBackendServers(lb *lbv1.LoadBalancer) ([]BackendServer, error)
-	// AddBackendServers returns true if backend servers are really added the LB, otherwise returns false
-	AddBackendServers(lb *lbv1.LoadBalancer, servers []BackendServer) (bool, error)
-	// RemoveBackendServers returns true if backend servers are really removed from the LB, otherwise returns false
-	RemoveBackendServers(lb *lbv1.LoadBalancer, servers []BackendServer) (bool, error)
+
+	// Step 2. Ensure loadbalancer external IP
+	EnsureLoadBalancerServiceIP(lb *lbv1.LoadBalancer) (string, error)
+
+	// Step 3. Ensure service backend servers
+	EnsureBackendServers(lb *lbv1.LoadBalancer) ([]BackendServer, error)
+
+	ListBackendServers(lb *lbv1.LoadBalancer) ([]BackendServer, error)
+
+	// return the count of endpoints which are probed as Ready
+	// if probe is disabled, then return the count of all endpoints
+	GetProbeReadyBackendServerCount(lb *lbv1.LoadBalancer) (int, error)
+
+	// register a handler to get which lb is happending changes per health check
+	RegisterHealthCheckHandler(handler HealthCheckHandler) error
 }
 
 type BackendServer interface {
@@ -22,3 +37,7 @@ type BackendServer interface {
 	GetName() string
 	GetAddress() (string, bool)
 }
+
+var (
+	ErrWaitExternalIP = errors.New("service is waiting for external IP")
+)

--- a/pkg/prober/health.go
+++ b/pkg/prober/health.go
@@ -12,6 +12,12 @@ type HealthOption struct {
 }
 
 type healthCondition struct {
-	workerUID string
-	isHealth  bool
+	uid       string
+	address   string
+	isHealthy bool
+}
+
+func (ho *HealthOption) Equal(h HealthOption) bool {
+	return ho.Address == h.Address && ho.SuccessThreshold == h.SuccessThreshold && ho.FailureThreshold == h.FailureThreshold &&
+		ho.Timeout == h.Timeout && ho.Period == h.Period
 }

--- a/pkg/webhook/loadbalancer/mutator_test.go
+++ b/pkg/webhook/loadbalancer/mutator_test.go
@@ -8,6 +8,10 @@ import (
 	harvesterfakeclients "github.com/harvester/harvester/pkg/util/fakeclients"
 	corefake "k8s.io/client-go/kubernetes/fake"
 
+	lbv1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/harvester/harvester-load-balancer/pkg/utils"
 )
 
@@ -39,11 +43,89 @@ func TestFindProject(t *testing.T) {
 		},
 	}
 
+	testsHealthCheckMutatored := []struct {
+		name    string
+		lb      *lbv1.LoadBalancer
+		wantErr bool
+		opsLen  int
+	}{
+		{
+			name: "health check mutatored case",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test",
+				},
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
+						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
+					},
+					HealthCheck: &lbv1.HealthCheck{Port: 80, SuccessThreshold: 0, FailureThreshold: 1, PeriodSeconds: 1, TimeoutSeconds: 1},
+				},
+			},
+			wantErr: false,
+			opsLen:  2,
+		},
+		{
+			name: "health check right case: valid parameters",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test",
+				},
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
+						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
+					},
+					HealthCheck: &lbv1.HealthCheck{Port: 80, SuccessThreshold: 1, FailureThreshold: 1, PeriodSeconds: 1, TimeoutSeconds: 1},
+				},
+			},
+			wantErr: false,
+			opsLen:  1,
+		},
+		{
+			name: "health check right case: no health check",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test",
+				},
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
+						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
+					},
+				},
+			},
+			wantErr: false,
+			opsLen:  1,
+		},
+	}
+
 	for _, test := range tests {
 		if project, err := m.findProject(test.namespace); err != nil {
 			t.Error(err)
 		} else if project != test.wantProject {
 			t.Errorf("want project %s through namespace %s, got %s", test.wantProject, test.namespace, project)
+		}
+	}
+
+	for _, test := range testsHealthCheckMutatored {
+		if pt, err := m.Create(nil, test.lb); (err != nil) != test.wantErr {
+			t.Error(err)
+		} else if len(pt) != test.opsLen {
+			// return 2 ops
+			// [{Op:replace Path:/metadata/annotations Value:map[loadbalancer.harvesterhci.io/namespace:default loadbalancer.harvesterhci.io/network: loadbalancer.harvesterhci.io/project:local/p-abcde]}
+			// {Op:replace Path:/spec/healthCheck Value:{Port:80 SuccessThreshold:2 FailureThreshold:1 PeriodSeconds:1 TimeoutSeconds:1}}]
+			t.Errorf("create test %v return patchOps len %v != %v, %+v", test.name, len(pt), test.opsLen, pt)
+		}
+
+		if pt, err := m.Update(nil, nil, test.lb); (err != nil) != test.wantErr {
+			t.Error(err)
+		} else if len(pt) != test.opsLen {
+			t.Errorf("update test %v return patchOps len %v != %v, %+v", test.name, len(pt), test.opsLen, pt)
 		}
 	}
 }

--- a/pkg/webhook/loadbalancer/validator.go
+++ b/pkg/webhook/loadbalancer/validator.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/harvester/webhook/pkg/server/admission"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	lbv1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
@@ -27,6 +28,10 @@ func (v *validator) Create(_ *admission.Request, newObj runtime.Object) error {
 		return fmt.Errorf("create loadbalancer %s/%s failed: %w", lb.Namespace, lb.Name, err)
 	}
 
+	if err := checkHealthyCheck(lb); err != nil {
+		return fmt.Errorf("create loadbalancer %s/%s failed with healthyCheck: %w", lb.Namespace, lb.Name, err)
+	}
+
 	return nil
 }
 
@@ -39,6 +44,10 @@ func (v *validator) Update(_ *admission.Request, oldObj, newObj runtime.Object) 
 
 	if err := checkListeners(lb); err != nil {
 		return fmt.Errorf("update loadbalancer %s/%s failed: %w", lb.Namespace, lb.Name, err)
+	}
+
+	if err := checkHealthyCheck(lb); err != nil {
+		return fmt.Errorf("update loadbalancer %s/%s failed with healthyCheck: %w", lb.Namespace, lb.Name, err)
 	}
 
 	return nil
@@ -58,8 +67,13 @@ func (v *validator) Resource() admission.Resource {
 	}
 }
 
+const maxPort = 65535
+
 func checkListeners(lb *lbv1.LoadBalancer) error {
 	nameMap, portMap, backendMap := map[string]bool{}, map[int32]int{}, map[int32]int{}
+	if len(lb.Spec.Listeners) == 0 {
+		return fmt.Errorf("the loadbalancer needs to have at least one listener")
+	}
 	for i, listener := range lb.Spec.Listeners {
 		// check listener name
 		if _, ok := nameMap[listener.Name]; ok {
@@ -80,6 +94,54 @@ func checkListeners(lb *lbv1.LoadBalancer) error {
 				listener.BackendPort, lb.Spec.Listeners[index].Name)
 		}
 		backendMap[listener.BackendPort] = i
+	}
+
+	for _, listener := range lb.Spec.Listeners {
+		// check listener name
+		if listener.Port > maxPort {
+			return fmt.Errorf("listener port %v must <= %v", listener.Port, maxPort)
+		} else if listener.Port < 1 {
+			return fmt.Errorf("listener port %v must >= 1", listener.Port)
+		}
+		if listener.BackendPort > maxPort {
+			return fmt.Errorf("listener backend port %v must <= %v", listener.Port, maxPort)
+		} else if listener.BackendPort < 1 {
+			return fmt.Errorf("listener backend port %v must >= 1", listener.Port)
+		}
+	}
+
+	return nil
+}
+
+func checkHealthyCheck(lb *lbv1.LoadBalancer) error {
+	if lb.Spec.HealthCheck != nil && lb.Spec.HealthCheck.Port != 0 {
+		wrongProtocol := false
+		for _, listener := range lb.Spec.Listeners {
+			// check listener port and protocol, only TCP is supported now
+			if uint(listener.BackendPort) == lb.Spec.HealthCheck.Port {
+				if listener.Protocol == corev1.ProtocolTCP {
+					if lb.Spec.HealthCheck.SuccessThreshold == 0 {
+						return fmt.Errorf("healthcheck SuccessThreshold should > 0")
+					}
+					if lb.Spec.HealthCheck.FailureThreshold == 0 {
+						return fmt.Errorf("healthcheck FailureThreshold should > 0")
+					}
+					if lb.Spec.HealthCheck.PeriodSeconds == 0 {
+						return fmt.Errorf("healthcheck PeriodSeconds should > 0")
+					}
+					if lb.Spec.HealthCheck.TimeoutSeconds == 0 {
+						return fmt.Errorf("healthcheck TimeoutSeconds should > 0")
+					}
+					return nil
+				}
+				// not the expected TCP
+				wrongProtocol = true
+			}
+		}
+		if wrongProtocol {
+			return fmt.Errorf("healthcheck port %v can only be a TCP backend port", lb.Spec.HealthCheck.Port)
+		}
+		return fmt.Errorf("healthcheck port %v is not in listener backend port list", lb.Spec.HealthCheck.Port)
 	}
 
 	return nil

--- a/pkg/webhook/loadbalancer/validator_test.go
+++ b/pkg/webhook/loadbalancer/validator_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	lbv1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestCheckListeners(t *testing.T) {
@@ -49,6 +50,54 @@ func TestCheckListeners(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "port < 1",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", Port: -1},
+						{Name: "b", Port: 80},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "port > 65535",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", Port: 80},
+						{Name: "b", Port: 8000},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "backend port < 1",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", BackendPort: 0},
+						{Name: "b", BackendPort: 80},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "backend port > 65535",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", BackendPort: 65536},
+						{Name: "b", BackendPort: 80},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "right case",
 			lb: &lbv1.LoadBalancer{
 				Spec: lbv1.LoadBalancerSpec{
@@ -62,9 +111,113 @@ func TestCheckListeners(t *testing.T) {
 		},
 	}
 
+	testsHealtyCheck := []struct {
+		name    string
+		lb      *lbv1.LoadBalancer
+		wantErr bool
+	}{
+		{
+			name: "health check port is not in backend port list",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
+						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
+					},
+					HealthCheck: &lbv1.HealthCheck{Port: 99},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "health check protocol is not expected tcp",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
+						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
+					},
+					HealthCheck: &lbv1.HealthCheck{Port: 32},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "health check parameter SuccessThreshold is error",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
+						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
+					},
+					HealthCheck: &lbv1.HealthCheck{Port: 80, SuccessThreshold: 0},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "health check parameter FailureThreshold is error",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
+						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
+					},
+					HealthCheck: &lbv1.HealthCheck{Port: 80, FailureThreshold: 0},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "health check parameter PeriodSeconds is error",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
+						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
+					},
+					HealthCheck: &lbv1.HealthCheck{Port: 80, PeriodSeconds: 0},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "health check parameter TimeoutSeconds is error",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
+						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
+					},
+					HealthCheck: &lbv1.HealthCheck{Port: 80, TimeoutSeconds: 0},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "health check right case",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					Listeners: []lbv1.Listener{
+						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
+						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
+					},
+					HealthCheck: &lbv1.HealthCheck{Port: 80, SuccessThreshold: 1, FailureThreshold: 1, PeriodSeconds: 1, TimeoutSeconds: 1},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
 	for _, tt := range tests {
 		if err := checkListeners(tt.lb); (err != nil) != tt.wantErr {
-			t.Errorf("%q. checkPorts() error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			t.Errorf("%q. checkListeners() error = %v, wantErr %v", tt.name, err, tt.wantErr)
+		}
+	}
+
+	for _, tt := range testsHealtyCheck {
+		if err := checkHealthyCheck(tt.lb); (err != nil) != tt.wantErr {
+			t.Errorf("%q. checkHealthyCheck() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 		}
 	}
 }


### PR DESCRIPTION
The optimizaitons:

1. Remove the strict limitation of at least one VM should exist when creating a LB

2. Refactor the controllers
2.1 VMI changes only enqueue LB, instead to add/remove backend servers
2.2 LB changes to `Not Ready` in case of errors like ip allocation failure, serivce failure, endpointslices failure...
2.3 Remove the controller looping waiting of External IP, use enqueue instead

3. Refactor the IP Allocation (TBD), the current code has a few bugs https://github.com/harvester/harvester/issues/5033#issuecomment-2083624425
...

Related issues:
https://github.com/harvester/harvester/issues/5316
https://github.com/harvester/harvester/issues/4821
https://github.com/harvester/harvester/issues/4972
https://github.com/harvester/harvester/issues/5033

Test plan:
(1) LB can be created alone when VM is not existing, the status Ready is False
(2) VM's can be added/removed to/from LB freely
(3) LB can allocate & free IP from/to pool robustly, test the IP exhausting of pool, even no VM instances.
(4) If health-check probe is enabled and all probe fails when there are at least 1 active VMs on this LB, the status Ready is False; if probe is disabled, the LB turns to Ready