### PR TITLE
chore: bump go version to v1.22

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.21
+FROM registry.suse.com/bci/golang:1.22
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/harvester-load-balancer
 
-go 1.21
+go 1.22
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.18


### PR DESCRIPTION
Bump go version to v1.22

Related issue: harvester/harvester#6160