### PR TITLE
Deny the change of IPAM to avoid IP leaking

### DIFF
--- a/pkg/webhook/ippool/validator.go
+++ b/pkg/webhook/ippool/validator.go
@@ -32,7 +32,7 @@ func NewIPPoolValidator(ipPoolCache ctllbv1.IPPoolCache) admission.Validator {
 func (i *ipPoolValidator) Create(_ *admission.Request, newObj runtime.Object) error {
 	pool := newObj.(*lbv1.IPPool)
 	if len(pool.Spec.Ranges) == 0 {
-		return fmt.Errorf(createErr, pool.Name, fmt.Errorf("range could not be empty"))
+		return fmt.Errorf(createErr, pool.Name, fmt.Errorf("range can't be empty"))
 	}
 
 	rs, err := ipam.LBRangesToAllocatorRangeSet(pool.Spec.Ranges)
@@ -64,7 +64,7 @@ func (i *ipPoolValidator) Update(_ *admission.Request, _, newObj runtime.Object)
 	}
 
 	if len(pool.Spec.Ranges) == 0 {
-		return fmt.Errorf(updateErr, pool.Name, fmt.Errorf("range could not be empty"))
+		return fmt.Errorf(updateErr, pool.Name, fmt.Errorf("range can't be empty"))
 	}
 
 	rs, err := ipam.LBRangesToAllocatorRangeSet(pool.Spec.Ranges)
@@ -96,7 +96,7 @@ func (i *ipPoolValidator) Delete(_ *admission.Request, oldObj runtime.Object) er
 	pool := oldObj.(*lbv1.IPPool)
 
 	if len(pool.Status.Allocated) != 0 {
-		return fmt.Errorf("could not delete pool before releasing all the allocated IP")
+		return fmt.Errorf("can't delete pool before releasing all the allocated IP")
 	}
 
 	return nil
@@ -246,7 +246,7 @@ func (i *ipPoolValidator) checkSelectorWithOthers(pool *lbv1.IPPool) error {
 		}
 		// priority could not be same if it's not zero
 		if p.Spec.Selector.Priority != 0 && p.Spec.Selector.Priority == pool.Spec.Selector.Priority {
-			return fmt.Errorf("the priority could not be the same as the pool %s", p.Name)
+			return fmt.Errorf("the priority can't be the same as the pool %s", p.Name)
 		} else if p.Spec.Selector.Priority == 0 && pool.Spec.Selector.Priority == 0 {
 			// check the scope overlaps if both of them are zero
 			r := &ipam.Requirement{
@@ -257,7 +257,7 @@ func (i *ipPoolValidator) checkSelectorWithOthers(pool *lbv1.IPPool) error {
 				r.Namespace = t.Namespace
 				r.Cluster = t.GuestCluster
 				if ipam.NewMatcher(p.Spec.Selector).Matches(r) {
-					return fmt.Errorf("scope overlaps with %s", p.Name)
+					return fmt.Errorf("scope selector is same as the pool %s with priority 0 Project %v Namespace %v GuestCluster %v, set a different priority or scope", p.Name, t.Project, t.Namespace, t.GuestCluster)
 				}
 			}
 		}


### PR DESCRIPTION
Deny the change of IPAM to avoid IP leaking
Add detailed error message for IPPool

It needs a more complex solution to support change the IPAM on the fly, to release IP to old IPAM and allocate IP from new IPAM, the PR just blocks the change. Currently, LB can be created as place-holder, it is easy to delete & create LB.

Issue: 
https://github.com/harvester/harvester/issues/6684
https://github.com/harvester/harvester/issues/6687

Local test:

Deny the change from Pool -> DHCP
![image](https://github.com/user-attachments/assets/e10d1b32-66a5-45af-b718-5dd7c625e028)

Deny the change from Dhcp -> Pool
![image](https://github.com/user-attachments/assets/fce66cad-add8-4961-ad44-e2616bfc70aa)


Priority 0 conflicts message:

![image](https://github.com/user-attachments/assets/f7ce8c7e-aca5-4aea-bd70-de83d87eea8e)
