### PR TITLE
fix: skip listener check for cluster lbs

### DIFF
--- a/pkg/webhook/loadbalancer/validator.go
+++ b/pkg/webhook/loadbalancer/validator.go
@@ -76,6 +76,12 @@ const maxPort = 65535
 
 func checkListeners(lb *lbv1.LoadBalancer) error {
 	nameMap, portMap, backendMap := map[string]bool{}, map[int32]int{}, map[int32]int{}
+
+	// Cluster-type load balancers can have no listeners since the actual load-balancing is done in the guest cluster.
+	if lb.Spec.WorkloadType == lbv1.Cluster {
+		return nil
+	}
+
 	if len(lb.Spec.Listeners) == 0 {
 		return fmt.Errorf("the loadbalancer needs to have at least one listener")
 	}

--- a/pkg/webhook/loadbalancer/validator_test.go
+++ b/pkg/webhook/loadbalancer/validator_test.go
@@ -109,6 +109,24 @@ func TestCheckListeners(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "VM-type lb should have listeners defined",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					WorkloadType: lbv1.VM,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "cluster-type lb can have no listeners",
+			lb: &lbv1.LoadBalancer{
+				Spec: lbv1.LoadBalancerSpec{
+					WorkloadType: lbv1.Cluster,
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	testsHealtyCheck := []struct {


### PR DESCRIPTION
**Problem**

When creating LB-type services in the guest cluster, the Harvester cloud provider will try to create an LB object in the underlying Harvester cluster. The Harvester load balancer's webhook has a listener check that checks whether the incoming LB object creation contains any listeners. It will reject the request if there's no listeners defined in the LB object.

**Solution**

Such a check should only apply to VM-type LBs but not cluster-type LBs, as the cluster-type LB represents only LB-type services in the guest cluster. This is especially true for DHCP IPAM LB-type services. Though it plays an important role for Pool IPAM LB-type services (IP allocation), it does nothing to do with backend load balancing (selectors and listeners). We can simply exclude the listener check for cluster-type LBs in the webhook.

**Related Issue**

harvester/harvester#6774

**Test Plan**

1. Have a v1.4.0-rc2 Harvester cluster up and running
2. Replace the harvester-load-balancer-webhook image with the one containing the fix
3. Add the Harvester cluster into Rancher
4. Create a guest cluster (RKE1 and RKE2)
5. Create a nginx Deployment workload with load balancer defined (DHCP and Pool IPAM)
6. Check the LB-type service's status
7. Check if you can access the nginx default webpage through the allocated LB IP