### PR TITLE
Add accurate error message about subnet error

### DIFF
--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -35,7 +35,7 @@ type SafeAllocatorMap struct {
 
 func NewAllocator(name string, ranges []lbv1.Range, cache ctllbv1.IPPoolCache, client ctllbv1.IPPoolClient) (*Allocator, error) {
 	if len(ranges) == 0 {
-		return nil, fmt.Errorf("range could not be empty")
+		return nil, fmt.Errorf("range can't be empty")
 	}
 
 	rangeSlice := make([]allocator.Range, 0)
@@ -63,7 +63,8 @@ func NewAllocator(name string, ranges []lbv1.Range, cache ctllbv1.IPPoolCache, c
 func MakeRange(r *lbv1.Range) (*allocator.Range, error) {
 	ip, ipNet, err := net.ParseCIDR(r.Subnet)
 	if err != nil {
-		return nil, fmt.Errorf("invalid range %+v", r)
+		// the return error is like: "invalid CIDR address: 192.168.300.0/24"
+		return nil, fmt.Errorf("%w, a valid example is 192.168.1.0/24", err)
 	}
 
 	var defaultStart, defaultEnd, defaultGateway, start, end, gateway net.IP

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -22,6 +22,10 @@ var (
 	p2pIPStr            = "192.168.100.10/32"
 	p2pIP               = net.IP{192, 168, 100, 10}
 	p2pMask             = net.IPv4Mask(255, 255, 255, 255)
+
+	cClassErrorSubnet1 = "192.168.100.0"
+	cClassErrorSubnet2 = "192.168.100.0/100"
+	cClassErrorSubnet3 = "192.168.300.0/24"
 )
 
 func newFakeAllocator(name string, ranges []lbv1.Range) (*Allocator, error) {
@@ -49,6 +53,44 @@ func newFakeAllocator(name string, ranges []lbv1.Range) (*Allocator, error) {
 		checkSum:    CalculateCheckSum(ranges),
 		total:       total,
 	}, nil
+}
+
+func TestAllocator_CheckSubnet(t *testing.T) {
+	tests := []struct {
+		name    string
+		subnet  string
+		wantErr bool
+	}{
+		{
+			name:    "test1",
+			subnet:  cClassErrorSubnet1,
+			wantErr: true,
+		},
+		{
+			name:    "test2",
+			subnet:  cClassErrorSubnet2,
+			wantErr: true,
+		},
+		{
+			name:    "test3",
+			subnet:  cClassErrorSubnet3,
+			wantErr: true,
+		},
+		{
+			name:    "test4",
+			subnet:  cClassSubnet,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newFakeAllocator(tt.name, []lbv1.Range{{Subnet: tt.subnet}})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("wantErr %v, returnErr %v", tt.wantErr, err != nil)
+			}
+		})
+	}
 }
 
 func TestAllocator_Total(t *testing.T) {

--- a/pkg/webhook/ippool/error.go
+++ b/pkg/webhook/ippool/error.go
@@ -1,6 +1,6 @@
 package ippool
 
 const (
-	createErr = "could not create IP pool %s because %w"
-	updateErr = "could not update IP pool %s because %w"
+	createErr = "can't create IP pool %s because %w"
+	updateErr = "can't update IP pool %s because %w"
 )


### PR DESCRIPTION
Issue: https://github.com/harvester/harvester/issues/6819

Local test:

Returned error
>admission webhook "validator.harvester-system.harvester-load-balancer-webhook" denied the request: Internal error occurred: can't create IP pool pool3 because invalid CIDR address: 192.168.10.1, a valid example is 192.168.1.0/24

![image](https://github.com/user-attachments/assets/99ea695b-944a-4154-af5c-47e60b67d823)

![image](https://github.com/user-attachments/assets/85d4b10b-0da2-4258-8539-a9061b64f967)

![image](https://github.com/user-attachments/assets/d541f14a-3f2c-45b6-afb2-f0effcf9a504)
