### PR TITLE
Make the build consistent across archs for Go to correctly report the package path inside the binary

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -9,6 +9,6 @@ mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
 
 for arch in "amd64" "arm64"; do
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-load-balancer-"$arch" main.go
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-load-balancer-webhook-"$arch" cmd/webhook/main.go
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-load-balancer-"$arch"
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-load-balancer-webhook-"$arch" ./cmd/webhook
 done


### PR DESCRIPTION
The build process is passing directly the `main.go` file for the build. According to Go's spec, this results in Go not properly identifying the package and module path and then marking the compiled binary as `command-line-arguments`.

Before:

```
> go version -m main
main: go1.22.9
	path	command-line-arguments
```

Now:

```
> go version -m harvester-load-balancer 
harvester-load-balancer: go1.22.9
	path	github.com/harvester/harvester-load-balancer
	mod	github.com/harvester/harvester-load-balancer	(devel)	
```

Although this is a minor thing and that doesn't affect the binary itself, it actually blocks security scanners, for example Trivy, from correctly matching the binary (and its path/module origin) with a VEX entry.

This was identified internally when a false-positive vulnerability that was supposed to be suppressed was still being reported in the scanning reports.