### PR TITLE
[v0.3.x] Make the build consistent across archs for Go to correctly report the package path inside the binary

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -9,6 +9,6 @@ mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
 
 for arch in "amd64" "arm64"; do
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-load-balancer-"$arch" main.go
-    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-load-balancer-webhook-"$arch" cmd/webhook/main.go
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-load-balancer-"$arch"
+    GOARCH="$arch" CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/harvester-load-balancer-webhook-"$arch" ./cmd/webhook
 done


### PR DESCRIPTION
Backport of https://github.com/harvester/load-balancer-harvester/pull/43.