### PR TITLE
Try to release IP if it has been allocated to current LB

### DIFF
--- a/pkg/controller/loadbalancer/controller.go
+++ b/pkg/controller/loadbalancer/controller.go
@@ -14,7 +14,6 @@ import (
 	ctlcorev1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 
-	lb "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io"
 	lbv1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester-load-balancer/pkg/config"
 	ctldiscoveryv1 "github.com/harvester/harvester-load-balancer/pkg/generated/controllers/discovery.k8s.io/v1"
@@ -27,12 +26,11 @@ import (
 const (
 	controllerName = "harvester-lb-controller"
 
-	AnnotationKeyNetwork   = lb.GroupName + "/network"
-	AnnotationKeyProject   = lb.GroupName + "/project"
-	AnnotationKeyNamespace = lb.GroupName + "/namespace"
-	AnnotationKeyCluster   = lb.GroupName + "/cluster"
-
-	DuplicateAllocationKeyWord = "duplicate allocation is not allowed"
+	// referred by cloud-provider-harvester
+	AnnotationKeyNetwork   = utils.AnnotationKeyNetwork
+	AnnotationKeyProject   = utils.AnnotationKeyProject
+	AnnotationKeyNamespace = utils.AnnotationKeyNamespace
+	AnnotationKeyCluster   = utils.AnnotationKeyCluster
 )
 
 var (
@@ -281,7 +279,7 @@ func (h *Handler) ensureAllocatedAddressPool(lbCopy, lb *lbv1.LoadBalancer) (*lb
 		if err != nil {
 			logrus.Debugf("lb %s/%s fail to allocate from pool %s", lb.Namespace, lb.Name, err.Error())
 			// if unlucky the DuplicateAllocationKeyWord is reported, try to release IP, do not overwrite original error
-			if strings.Contains(err.Error(), DuplicateAllocationKeyWord) {
+			if strings.Contains(err.Error(), utils.DuplicateAllocationKeyWord) {
 				pool, releaseErr := h.tryReleaseDuplicatedIPToPool(lb)
 				if releaseErr != nil {
 					logrus.Infof("lb %s/%s error: %s, try to release ip to pool %s, error: %s", lb.Namespace, lb.Name, err.Error(), pool, releaseErr.Error())
@@ -353,10 +351,10 @@ func (h *Handler) requestIP(lb *lbv1.LoadBalancer, pool string) (*lbv1.Allocated
 
 func (h *Handler) selectIPPool(lb *lbv1.LoadBalancer) (string, error) {
 	r := &ipam.Requirement{
-		Network:   lb.Annotations[AnnotationKeyNetwork],
-		Project:   lb.Annotations[AnnotationKeyProject],
-		Namespace: lb.Annotations[AnnotationKeyNamespace],
-		Cluster:   lb.Annotations[AnnotationKeyCluster],
+		Network:   lb.Annotations[utils.AnnotationKeyNetwork],
+		Project:   lb.Annotations[utils.AnnotationKeyProject],
+		Namespace: lb.Annotations[utils.AnnotationKeyNamespace],
+		Cluster:   lb.Annotations[utils.AnnotationKeyCluster],
 	}
 	if r.Namespace == "" {
 		r.Namespace = lb.Namespace

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -12,4 +12,9 @@ const (
 	AnnotationKeyProject   = lb.GroupName + "/project"
 	AnnotationKeyNamespace = lb.GroupName + "/namespace"
 	AnnotationKeyCluster   = lb.GroupName + "/cluster"
+
+	// value format: loadbalancer.harvesterhci.io/manuallyReleaseIP: "192.168.5.12: default/cluster1-lb-3"
+	AnnotationKeyManuallyReleaseIP = lb.GroupName + "/manuallyReleaseIP"
+
+	DuplicateAllocationKeyWord = "duplicate allocation is not allowed"
 )

--- a/pkg/utils/vid.go
+++ b/pkg/utils/vid.go
@@ -47,3 +47,24 @@ func GetVid(network string, nadCache ctlcniv1.NetworkAttachmentDefinitionCache) 
 	}
 	return netConf.VLAN, nil
 }
+
+// input format: "192.168.5.12: default/cluster1-lb-3"
+func SplitIPAllocatedString(ipStr string) (ip, namespace, name string, err error) {
+	ipStr = strings.Trim(ipStr, " ")
+	fields := strings.Split(ipStr, ":")
+	if len(fields) != 2 {
+		err = fmt.Errorf("%s is not a valid allocation record", ipStr)
+		return
+	}
+	nsnameStr := strings.Trim(fields[1], " ")
+	fields2 := strings.Split(nsnameStr, "/")
+	if len(fields2) != 2 {
+		err = fmt.Errorf("%s is not a valid allocation record", ipStr)
+		return
+	}
+	ip = fields[0]
+	namespace = fields2[0]
+	name = fields2[1]
+	err = nil
+	return
+}


### PR DESCRIPTION
To solve the duplicated allocation error when LB is frequently created and deleted.


In case LB is repeatedly created and deleted, the deletion onRemove may not be called due to UUID change on the same namespace/name object.

Solution:
1. Check return error of IP allocation, if it contains the keyword, then try to release it.
2. Add an annotation to manually release an dangling IP allocation record

issue:
https://github.com/harvester/harvester/issues/7449

Test plan: https://github.com/harvester/load-balancer-harvester/pull/47#issuecomment-2643143192