### PR TITLE
Fix the var value return

### DIFF
--- a/pkg/controller/loadbalancer/controller.go
+++ b/pkg/controller/loadbalancer/controller.go
@@ -314,9 +314,10 @@ func (h *Handler) allocateIPFromPool(lb *lbv1.LoadBalancer) (*lbv1.AllocatedAddr
 
 func (h *Handler) tryReleaseDuplicatedIPToPool(lb *lbv1.LoadBalancer) (string, error) {
 	pool := lb.Spec.IPPool
+	var err error
 	if pool == "" {
 		// match an IP pool automatically if not specified
-		pool, err := h.selectIPPool(lb)
+		pool, err = h.selectIPPool(lb)
 		if err != nil {
 			return pool, err
 		}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

When select a pool dynamically, the return pool name was set to empty by local var

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Fix the returned value

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8221

#### Test plan:
<!-- Describe the test plan by steps. -->

An image was sent to the issue reporter, and it solved the issue on the env right now.

https://github.com/harvester/harvester/issues/8221#issuecomment-2864139116

#### Additional documentation or context
