### PR TITLE
Fix converter panic

### DIFF
--- a/pkg/webhook/loadbalancer/converter.go
+++ b/pkg/webhook/loadbalancer/converter.go
@@ -147,8 +147,10 @@ func (c *converter) convertFromV1beta1ToV1alpha1(obj *unstructured.Unstructured)
 	}
 
 	// BackendServers
-	status := obj.Object[keyStatus].(map[string]interface{})
-	spec[keyBackendServers] = status[keyBackendServers]
+	if obj.Object[keyStatus] != nil {
+		status := obj.Object[keyStatus].(map[string]interface{})
+		spec[keyBackendServers] = status[keyBackendServers]
+	}
 
 	obj.Object[keySpec] = spec
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Webhook converter runs into panic.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Fix it.

BTW:
**The converter seems could be removed, but it is not done on this PR.**

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/9103

#### Test plan:
<!-- Describe the test plan by steps. -->

Per issue description, https://github.com/harvester/harvester/issues/9103#issue-3397101001, after the fix, panic is not observed.

#### Additional documentation or context

The panic can't be tested from converter_test.go, even when constructing a lb v1beta1 object without `status` info on the yaml or obj struct, the marshalled object still has a non-nil status field.

But on the run-time webhook, the `obj.Object[keyStatus]` is nil and can't be converted to `map[string]interface{}` directly.