### PR TITLE
Optimize LB webhook with more backward compatibility

### DIFF
--- a/pkg/webhook/loadbalancer/validator.go
+++ b/pkg/webhook/loadbalancer/validator.go
@@ -22,6 +22,8 @@ type validator struct {
 	vmiCache ctlkubevirtv1.VirtualMachineInstanceCache
 }
 
+const defaultGuestClusterName = "kubernetes"
+
 var _ admission.Validator = &validator{}
 
 func NewValidator(vmCache ctlkubevirtv1.VirtualMachineCache, vmiCache ctlkubevirtv1.VirtualMachineInstanceCache) admission.Validator {
@@ -216,30 +218,73 @@ func (v *validator) checkGuestClusterIsOnRemove(lb *lbv1.LoadBalancer) error {
 	}
 
 	gcName, ok := utils.GetGuestClusterNameFromLB(lb)
+	// The cluster name label is missing from the LoadBalancer metadata
+	// This prevents the controller from verifying if the guest cluster is being removed
+	// We allow this to maintain backward compatibility with legacy or custom clusters
 	if !ok {
-		logrus.Warnf("can't get the guest cluster name from lb %s/%s, skip checking of if guest cluster is on remove", lb.Namespace, lb.Name)
+		logrus.WithFields(logrus.Fields{
+			"namespace": lb.Namespace,
+			"name":      lb.Name,
+		}).Warnf("guest cluster name is missing from label '%s': skipping cluster removal state check for backward compatibility.",
+			utils.LabelKeyGuestClusterNameOnLB)
 		return nil
 	}
 
-	// list all the vm instance in the same namespace of the load balancer
-	// the guestcluster name is also required as multi guest cluster might coexist on a namespace
-	vms, err := v.vmCache.List(lb.Namespace, labels.Set(map[string]string{
+	// For backward compatibility, we don't check when the cluster name is empty or the default ("kubernetes")
+	// WARNING: Using the default name may prevent the LoadBalancer auto-reclaim feature
+	// from uniquely identifying this cluster, potentially leading to resource leakage or accidental deletion
+	if gcName == "" || gcName == defaultGuestClusterName {
+		logrus.WithFields(logrus.Fields{
+			"namespace": lb.Namespace,
+			"name":      lb.Name,
+			"cluster":   gcName,
+		}).Warn("Harvester LB auto-reclaim risk: ambiguous guest cluster name may cause resource leakage or accidental deletion, skipping cluster removal state check for backward compatibility")
+
+		return nil
+	}
+
+	// List all VMs within the same namespace as the LoadBalancer
+	// The guest cluster name is required because multiple guest clusters may coexist in a single namespace
+	// Note: Only Rancher Manager-managed guest clusters follow this labeling convention
+	// custom or manual guest clusters may not adhere to this requirement
+	selector := labels.Set(map[string]string{
 		utils.LabelKeyHarvesterCreator:     utils.GuestClusterHarvesterNodeDriver,
 		utils.LabelKeyGuestClusterNameOnVM: gcName,
-	}).AsSelector())
+	}).AsSelector()
+	vms, err := v.vmCache.List(lb.Namespace, selector)
 	if err != nil {
 		return fmt.Errorf("list vm from %s failed, error: %w", lb.Namespace, err)
 	}
 
+	// Return nil to accommodate two scenarios:
+	// 1. Custom Clusters: The guest cluster doesn't follow standard labeling
+	// 2. Deletion Race: The VMs were already purged during an RKE2 cluster removal
+	// To maintain backward compatibility for custom setups, we skip the LB creation check
 	if len(vms) == 0 {
-		return fmt.Errorf("it has no running vm")
+		logrus.WithFields(logrus.Fields{
+			"namespace": lb.Namespace,
+			"name":      lb.Name,
+			"cluster":   gcName,
+		}).Warnf("No VMs found with selector %s: skipping cluster removal state check for backward compatibility",
+			selector.String())
+		return nil
 	}
 
+	// For backward compatibility, we only deny LoadBalancer creation in this specific state:
+	// When Rancher Manager initiates a guest cluster deletion, it marks all constituent VMs
+	// with the 'AnnotationKeyGuestClusterOnRemove' annotation
+	// If a new LoadBalancer request arrives during this teardown phase, it is rejected
+	// to prevent orphaned resources
 	for _, vm := range vms {
 		if utils.IsVmWithGuestClusterOnRemoveAnnotation(vm) {
-			return fmt.Errorf("the vm %s/%s shows guest cluster is on remove", vm.Namespace, vm.Name)
+			logrus.WithFields(logrus.Fields{
+				"namespace": lb.Namespace,
+				"name":      lb.Name,
+			}).Debugf("the vm %s/%s shows guest cluster %s is being removed",
+				vm.Namespace, vm.Name, gcName)
+
+			return fmt.Errorf("the vm %s/%s shows guest cluster %s is being removed", vm.Namespace, vm.Name, gcName)
 		}
 	}
-
 	return nil
 }

--- a/pkg/webhook/loadbalancer/validator_test.go
+++ b/pkg/webhook/loadbalancer/validator_test.go
@@ -584,10 +584,10 @@ func Test_BlockNewLBWhenGuestClusterIsOnRemove(t *testing.T) {
 				},
 			},
 			wantErr:  true,
-			errorKey: "guest cluster is on remove",
+			errorKey: "is being removed",
 		},
 		{
-			name: "guest cluster has no vm, can't create new lb",
+			name: "guest cluster has no vm, create new lb for backward compatibility",
 			lb: &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "non-existing",
@@ -601,8 +601,8 @@ func Test_BlockNewLBWhenGuestClusterIsOnRemove(t *testing.T) {
 				},
 			},
 			vm:       &kubevirtv1.VirtualMachine{},
-			wantErr:  true,
-			errorKey: "has no running vm",
+			wantErr:  false,
+			errorKey: "",
 		},
 		{
 			name: "guest cluster has normal vm, can create new lb",
@@ -626,6 +626,131 @@ func Test_BlockNewLBWhenGuestClusterIsOnRemove(t *testing.T) {
 						utils.LabelKeyHarvesterCreator:     utils.GuestClusterHarvesterNodeDriver,
 						utils.LabelKeyGuestClusterNameOnVM: "gc1",
 					},
+				},
+			},
+			wantErr:  false,
+			errorKey: "",
+		},
+		{
+			name: "lb guest cluster name missing, pass", // e.g. cloud-provider-harvester chart is not installed with a clustername
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "removing",
+					Name:      "lb1",
+					Labels:    map[string]string{},
+				},
+				Spec: lbv1.LoadBalancerSpec{
+					WorkloadType: lbv1.Cluster,
+				},
+			},
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "removing",
+					Name:        "vm1",
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+			},
+			wantErr:  false,
+			errorKey: "",
+		},
+		{
+			name: "lb guest cluster name is the default kubernetes, allow pass",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "removing",
+					Name:      "lb1",
+					Labels: map[string]string{
+						utils.LabelKeyGuestClusterNameOnLB: defaultGuestClusterName,
+					},
+				},
+				Spec: lbv1.LoadBalancerSpec{
+					WorkloadType: lbv1.Cluster,
+				},
+			},
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "removing",
+					Name:        "vm1",
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+			},
+			wantErr:  false,
+			errorKey: "",
+		},
+		{
+			name: "lb guest cluster name is an empty string, pass for backward compatibility", // e.g. cloud-provider-harvester chart is installed with an empty clustername
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "removing",
+					Name:      "lb1",
+					Labels: map[string]string{
+						utils.LabelKeyGuestClusterNameOnLB: "",
+					},
+				},
+				Spec: lbv1.LoadBalancerSpec{
+					WorkloadType: lbv1.Cluster,
+				},
+			},
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "removing",
+					Name:        "vm1",
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+			},
+			wantErr:  false,
+			errorKey: "",
+		},
+		{
+			name: "vm guest cluster name missing, pass for backward compatibility", // case like the customized guest cluster, the VM does not include required label
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "customized",
+					Name:      "lb1",
+					Labels: map[string]string{
+						utils.LabelKeyGuestClusterNameOnLB: "gc1",
+					},
+				},
+				Spec: lbv1.LoadBalancerSpec{
+					WorkloadType: lbv1.Cluster,
+				},
+			},
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "customized",
+					Name:        "vm1",
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+			},
+			wantErr:  false,
+			errorKey: "",
+		},
+		{
+			name: "vm creator name missing, pass for backward compatibility", // case like the customized guest cluster, the VM does not include required label
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "customized",
+					Name:      "lb1",
+					Labels: map[string]string{
+						utils.LabelKeyGuestClusterNameOnLB: "gc1",
+					},
+				},
+				Spec: lbv1.LoadBalancerSpec{
+					WorkloadType: lbv1.Cluster,
+				},
+			},
+			vm: &kubevirtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "customized",
+					Name:      "vm1",
+					Labels: map[string]string{
+						utils.LabelKeyGuestClusterNameOnVM: "gc1",
+					},
+					Annotations: map[string]string{},
 				},
 			},
 			wantErr:  false,


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Some legcy guest cluster might not follow all standards to have clustername on cloud-provider chart deployment and labels on guest cluster node (Harvester VM), it causes such scenario sometimes is not working as expected:

>the LB webhook checks to ensure at least one guest VM is existing when creating LB

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Warn those cases and allow to pass, to keep backward compatibility

2. Optimize the return error to have a clean description

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10527 (dedicated for relax the LB to get better backward compatibility)

https://github.com/harvester/harvester/issues/10399 (partially related)

#### Test plan:
<!-- Describe the test plan by steps. -->

Refer https://github.com/harvester/harvester/issues/10527#issuecomment-4378271534



#### Additional documentation or context
