### PR TITLE
Support named network by guest cluster when creating LB

### DIFF
--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -33,6 +33,25 @@ const (
 	LabelKeyHarvesterCreator        = "harvesterhci.io/creator"
 	GuestClusterHarvesterNodeDriver = "docker-machine-driver-harvester"
 
+	HarvesterCloudProvider = "cloudprovider.harvesterhci.io"
+
+	HarvesterCloudProviderPrefix = HarvesterCloudProvider + "/"
+
+	// new definitions
+	NetworkTypeManagement = "managementNetwork"
+
+	NetworkTypeLB = "loadbalancerNetwork"
+
+	// if guest cluster sets a target network, then respect it
+	// on first priority
+	AnnotationKeyGuestClusterNetworkNameOnLB = HarvesterCloudProviderPrefix + NetworkTypeLB
+
+	// when guest cluster has multi network, it can explicitly say which one is the management network, instead of guess or hardcode
+	// on second priority
+	AnnotationKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + NetworkTypeManagement
+
+	// fallbackmode, the network is fetched from the guest cluster's VM's first multu-network
+
 	// guest cluster used VM has such label: guestcluster.harvesterhci.io/name: gc3
 	LabelKeyGuestClusterNameOnVM = "guestcluster.harvesterhci.io/name"
 

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -38,12 +38,9 @@ const (
 
 	HarvesterCloudProviderPrefix = HarvesterCloudProvider + "/"
 
-	// new definitions
 	NetworkTypeManagement = "managementNetwork"
 
-	NetworkTypeLB = "loadbalancerNetwork"
-
-	// when guest cluster has multi network, it can explicitly say which one is the management network, instead of guess or hardcode
+	// When the guest cluster has multiple networks, it can explicitly specify which one is the management network, instead of guessing or hardcoding.
 	AnnotationKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + NetworkTypeManagement
 
 	// guest cluster used VM has such label: guestcluster.harvesterhci.io/name: gc3

--- a/pkg/utils/const.go
+++ b/pkg/utils/const.go
@@ -15,6 +15,7 @@ const (
 
 	Address4AskDHCP = "0.0.0.0"
 
+	// guest cluster could set this for a specific target network
 	AnnotationKeyNetwork   = lb.GroupName + "/network"
 	AnnotationKeyProject   = lb.GroupName + "/project"
 	AnnotationKeyNamespace = lb.GroupName + "/namespace"
@@ -42,15 +43,8 @@ const (
 
 	NetworkTypeLB = "loadbalancerNetwork"
 
-	// if guest cluster sets a target network, then respect it
-	// on first priority
-	AnnotationKeyGuestClusterNetworkNameOnLB = HarvesterCloudProviderPrefix + NetworkTypeLB
-
 	// when guest cluster has multi network, it can explicitly say which one is the management network, instead of guess or hardcode
-	// on second priority
 	AnnotationKeyGuestClusterManagementNetworkOnLB = HarvesterCloudProviderPrefix + NetworkTypeManagement
-
-	// fallbackmode, the network is fetched from the guest cluster's VM's first multu-network
 
 	// guest cluster used VM has such label: guestcluster.harvesterhci.io/name: gc3
 	LabelKeyGuestClusterNameOnVM = "guestcluster.harvesterhci.io/name"

--- a/pkg/utils/selector.go
+++ b/pkg/utils/selector.go
@@ -25,14 +25,14 @@ func NewGuestClusterCreatorSelector() labels.Selector {
 	}).AsSelector()
 }
 
-// the selector to match clustername
+// the selector to match cluster name
 func NewGuestClusterNameSelector(gcName string) labels.Selector {
 	return labels.Set(map[string]string{
 		LabelKeyGuestClusterNameOnVM: gcName,
 	}).AsSelector()
 }
 
-// the selector to match both creator and clustername
+// the selector to match both creator and cluster name
 func NewGuestClusterNameAndCreatorNameSelector(gcName string) labels.Selector {
 	return labels.Set(map[string]string{
 		LabelKeyHarvesterCreator:     GuestClusterHarvesterNodeDriver,

--- a/pkg/utils/selector.go
+++ b/pkg/utils/selector.go
@@ -18,21 +18,22 @@ func NewSelector(selector map[string][]string) (labels.Selector, error) {
 	return s.Add(requirements...), nil
 }
 
-// the selecotr to match creator
-func NewGuestClusterCreatorSelecotr() labels.Selector {
+// the selector to match creator
+func NewGuestClusterCreatorSelector() labels.Selector {
 	return labels.Set(map[string]string{
 		LabelKeyHarvesterCreator: GuestClusterHarvesterNodeDriver,
 	}).AsSelector()
 }
 
-// the selecotr to match clustername
-func NewGuestClusterNameSelecotr(gcName string) labels.Selector {
+// the selector to match clustername
+func NewGuestClusterNameSelector(gcName string) labels.Selector {
 	return labels.Set(map[string]string{
 		LabelKeyGuestClusterNameOnVM: gcName,
 	}).AsSelector()
 }
 
-func NewGuestClusterNameAndCreatorNameSelecotr(gcName string) labels.Selector {
+// the selector to match both creator and clustername
+func NewGuestClusterNameAndCreatorNameSelector(gcName string) labels.Selector {
 	return labels.Set(map[string]string{
 		LabelKeyHarvesterCreator:     GuestClusterHarvesterNodeDriver,
 		LabelKeyGuestClusterNameOnVM: gcName,

--- a/pkg/utils/selector.go
+++ b/pkg/utils/selector.go
@@ -17,3 +17,24 @@ func NewSelector(selector map[string][]string) (labels.Selector, error) {
 	}
 	return s.Add(requirements...), nil
 }
+
+// the selecotr to match creator
+func NewGuestClusterCreatorSelecotr() labels.Selector {
+	return labels.Set(map[string]string{
+		LabelKeyHarvesterCreator: GuestClusterHarvesterNodeDriver,
+	}).AsSelector()
+}
+
+// the selecotr to match clustername
+func NewGuestClusterNameSelecotr(gcName string) labels.Selector {
+	return labels.Set(map[string]string{
+		LabelKeyGuestClusterNameOnVM: gcName,
+	}).AsSelector()
+}
+
+func NewGuestClusterNameAndCreatorNameSelecotr(gcName string) labels.Selector {
+	return labels.Set(map[string]string{
+		LabelKeyHarvesterCreator:     GuestClusterHarvesterNodeDriver,
+		LabelKeyGuestClusterNameOnVM: gcName,
+	}).AsSelector()
+}

--- a/pkg/utils/selector_test.go
+++ b/pkg/utils/selector_test.go
@@ -6,8 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func Test_NewGuestClusterCreatorSelecotr(t *testing.T) {
-	selector := NewGuestClusterCreatorSelecotr()
+func TestNewGuestClusterCreatorSelector(t *testing.T) {
+	selector := NewGuestClusterCreatorSelector()
 
 	tests := []struct {
 		name   string
@@ -15,14 +15,14 @@ func Test_NewGuestClusterCreatorSelecotr(t *testing.T) {
 		want   bool
 	}{
 		{
-			name: "match correct creator",
+			name: "match creator",
 			labels: labels.Set{
 				LabelKeyHarvesterCreator: GuestClusterHarvesterNodeDriver,
 			},
 			want: true,
 		},
 		{
-			name: "mismatch different creator",
+			name: "does not match creator",
 			labels: labels.Set{
 				LabelKeyHarvesterCreator: "manual-creation",
 			},
@@ -39,9 +39,9 @@ func Test_NewGuestClusterCreatorSelecotr(t *testing.T) {
 	}
 }
 
-func Test_NewGuestClusterNameSelecotr(t *testing.T) {
+func TestNewGuestClusterNameSelector(t *testing.T) {
 	clusterName := "test-cluster"
-	selector := NewGuestClusterNameSelecotr(clusterName)
+	selector := NewGuestClusterNameSelector(clusterName)
 
 	tests := []struct {
 		name   string
@@ -49,60 +49,16 @@ func Test_NewGuestClusterNameSelecotr(t *testing.T) {
 		want   bool
 	}{
 		{
-			name: "match correct cluster name",
+			name: "match cluster name",
 			labels: labels.Set{
 				LabelKeyGuestClusterNameOnVM: clusterName,
 			},
 			want: true,
 		},
 		{
-			name: "mismatch wrong cluster name",
+			name: "does not match cluster name",
 			labels: labels.Set{
 				LabelKeyGuestClusterNameOnVM: "other-cluster",
-			},
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := selector.Matches(tt.labels); got != tt.want {
-				t.Errorf("Matches() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_NewGuestClusterNameAndCreatorNameSelecotr(t *testing.T) {
-	clusterName := "production-cluster"
-	selector := NewGuestClusterNameAndCreatorNameSelecotr(clusterName)
-
-	tests := []struct {
-		name   string
-		labels labels.Set
-		want   bool
-	}{
-		{
-			name: "match both labels correctly",
-			labels: labels.Set{
-				LabelKeyHarvesterCreator:     GuestClusterHarvesterNodeDriver,
-				LabelKeyGuestClusterNameOnVM: clusterName,
-			},
-			want: true,
-		},
-		{
-			name: "fail on incorrect creator",
-			labels: labels.Set{
-				LabelKeyHarvesterCreator:     "custom-driver",
-				LabelKeyGuestClusterNameOnVM: clusterName,
-			},
-			want: false,
-		},
-		{
-			name: "fail on incorrect name",
-			labels: labels.Set{
-				LabelKeyHarvesterCreator:     GuestClusterHarvesterNodeDriver,
-				LabelKeyGuestClusterNameOnVM: "dev-cluster",
 			},
 			want: false,
 		},

--- a/pkg/utils/selector_test.go
+++ b/pkg/utils/selector_test.go
@@ -1,0 +1,118 @@
+package utils
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func Test_NewGuestClusterCreatorSelecotr(t *testing.T) {
+	selector := NewGuestClusterCreatorSelecotr()
+
+	tests := []struct {
+		name   string
+		labels labels.Set
+		want   bool
+	}{
+		{
+			name: "match correct creator",
+			labels: labels.Set{
+				LabelKeyHarvesterCreator: GuestClusterHarvesterNodeDriver,
+			},
+			want: true,
+		},
+		{
+			name: "mismatch different creator",
+			labels: labels.Set{
+				LabelKeyHarvesterCreator: "manual-creation",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selector.Matches(tt.labels); got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_NewGuestClusterNameSelecotr(t *testing.T) {
+	clusterName := "test-cluster"
+	selector := NewGuestClusterNameSelecotr(clusterName)
+
+	tests := []struct {
+		name   string
+		labels labels.Set
+		want   bool
+	}{
+		{
+			name: "match correct cluster name",
+			labels: labels.Set{
+				LabelKeyGuestClusterNameOnVM: clusterName,
+			},
+			want: true,
+		},
+		{
+			name: "mismatch wrong cluster name",
+			labels: labels.Set{
+				LabelKeyGuestClusterNameOnVM: "other-cluster",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selector.Matches(tt.labels); got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_NewGuestClusterNameAndCreatorNameSelecotr(t *testing.T) {
+	clusterName := "production-cluster"
+	selector := NewGuestClusterNameAndCreatorNameSelecotr(clusterName)
+
+	tests := []struct {
+		name   string
+		labels labels.Set
+		want   bool
+	}{
+		{
+			name: "match both labels correctly",
+			labels: labels.Set{
+				LabelKeyHarvesterCreator:     GuestClusterHarvesterNodeDriver,
+				LabelKeyGuestClusterNameOnVM: clusterName,
+			},
+			want: true,
+		},
+		{
+			name: "fail on incorrect creator",
+			labels: labels.Set{
+				LabelKeyHarvesterCreator:     "custom-driver",
+				LabelKeyGuestClusterNameOnVM: clusterName,
+			},
+			want: false,
+		},
+		{
+			name: "fail on incorrect name",
+			labels: labels.Set{
+				LabelKeyHarvesterCreator:     GuestClusterHarvesterNodeDriver,
+				LabelKeyGuestClusterNameOnVM: "dev-cluster",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selector.Matches(tt.labels); got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/selector_test.go
+++ b/pkg/utils/selector_test.go
@@ -72,3 +72,52 @@ func TestNewGuestClusterNameSelector(t *testing.T) {
 		})
 	}
 }
+
+func TestNewGuestClusterNameAndCreatorNameSelector(t *testing.T) {
+	clusterName := "test-cluster"
+	selector := NewGuestClusterNameAndCreatorNameSelector(clusterName)
+
+	tests := []struct {
+		name   string
+		labels labels.Set
+		want   bool
+	}{
+		{
+			name: "match cluster name and creator",
+			labels: labels.Set{
+				LabelKeyGuestClusterNameOnVM: clusterName,
+				LabelKeyHarvesterCreator:     GuestClusterHarvesterNodeDriver,
+			},
+			want: true,
+		},
+		{
+			name: "does not match cluster name",
+			labels: labels.Set{
+				LabelKeyGuestClusterNameOnVM: "other-cluster",
+				LabelKeyHarvesterCreator:     GuestClusterHarvesterNodeDriver,
+			},
+			want: false,
+		},
+		{
+			name: "does not match creator",
+			labels: labels.Set{
+				LabelKeyGuestClusterNameOnVM: clusterName,
+				LabelKeyHarvesterCreator:     "other-driver",
+			},
+			want: false,
+		},
+		{
+			name:   "does not match any",
+			labels: labels.Set{},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selector.Matches(tt.labels); got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/webhook/loadbalancer/converter.go
+++ b/pkg/webhook/loadbalancer/converter.go
@@ -197,7 +197,6 @@ func (c *converter) getPoolByAddressOfV1alpha1LB(addr, lbName, lbNamespace strin
 
 	for _, pool := range pools {
 		if pool.Status.Allocated[addr] == name {
-			logrus.Infof("pool: %s, name: %s", pool.Name, name)
 			return pool.Name, nil
 		}
 	}

--- a/pkg/webhook/loadbalancer/mutator.go
+++ b/pkg/webhook/loadbalancer/mutator.go
@@ -254,7 +254,7 @@ func (m *mutator) findNetwork(lb *lbv1.LoadBalancer) (string, error) {
 		return "", nil
 	}
 
-	// use cluster-name to match
+	// Use cluster-name to match
 	clusterNameSelector := utils.NewGuestClusterNameSelector(clusterName)
 	cnVMIs, err := m.vmiCache.List(lb.Namespace, clusterNameSelector)
 	if err != nil {
@@ -264,9 +264,11 @@ func (m *mutator) findNetwork(lb *lbv1.LoadBalancer) (string, error) {
 		return name, nil
 	}
 
-	// use creator to match
-	// might get a wrong network when there are multi guest clusters on a same namespace
-	// keep it for backward compatibility
+	// Use creator to match.
+	// Note:
+	// This is the legacy behavior, used as a last resort for backward compatibility.
+	// It may resolve to the wrong network if multiple guest clusters share the same namespace;
+	// therefore, the guest cluster must adapt to the first two strategies.
 	creatorSelector := utils.NewGuestClusterCreatorSelector()
 	creatorVMIs, err := m.vmiCache.List(lb.Namespace, creatorSelector)
 	if err != nil {

--- a/pkg/webhook/loadbalancer/mutator.go
+++ b/pkg/webhook/loadbalancer/mutator.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/harvester/webhook/pkg/server/admission"
 	rancherproject "github.com/rancher/rancher/pkg/project"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
@@ -149,13 +151,13 @@ func (m *mutator) getAnnotationsPatchCluster(lb *lbv1.LoadBalancer) (admission.P
 		return nil, err
 	}
 
-	network, err := m.findNetwork(lb, lb.Annotations[utils.AnnotationKeyCluster])
+	network, err := m.findNetwork(lb)
 	if err != nil {
 		return nil, err
 	}
 
 	// per the carried annotation like `loadbalancer.harvesterhci.io/cluster: gc1`
-	// additional annotations are mutated
+	// additional annotations are mutated or kept
 	//
 	//   loadbalancer.harvesterhci.io/namespace: default
 	//   loadbalancer.harvesterhci.io/network: default/vm-untag
@@ -179,7 +181,7 @@ func (m *mutator) getAnnotationsPatchCluster(lb *lbv1.LoadBalancer) (admission.P
 }
 
 func (m *mutator) getAnnotationsPatch(lb *lbv1.LoadBalancer) (admission.Patch, error) {
-	if lb.Spec.WorkloadType == lbv1.VM {
+	if lb.Spec.WorkloadType == lbv1.VM || lb.Spec.WorkloadType == "" {
 		return m.getAnnotationsPatchVM(lb)
 	}
 	return m.getAnnotationsPatchCluster(lb)
@@ -210,41 +212,66 @@ func (m *mutator) findProject(namespace string) (string, error) {
 	return strings.Replace(ns.Annotations[rancherproject.ProjectIDAnn], ":", "/", 1), nil
 }
 
-// findNetwork identifies the target network for the guest cluster using a priority-based approach:
-// 1. Explicit Network: AnnotationKeyGuestClusterNetworkNameOnLB
-// 2. Management Network: AnnotationKeyGuestClusterManagementNetworkOnLB
-// 3. Discovery (New): Use both creator and cluster-name to match, it ensures the vm is belonging to this cluster.
-// 4. Discovery (Legacy): It selects vm by creator label, and then match by vm name prefix.
+// findNetwork identifies the target network for the guest cluster.
+//
+// Precondition:
+// The LoadBalancer must contain the cluster-name annotation (utils.AnnotationKeyCluster).
+// If missing, the function exits early with an empty result as discovery is impossible.
+//
+// Priority-based Resolution:
+//  1. Explicit Network: Uses the value from AnnotationKeyNetwork if present.
+//  2. Management Network: Uses the value from AnnotationKeyGuestClusterManagementNetworkOnLB if present.
+//  3. Discovery (Modern): Matches VMIs by creator cluster-name labels to ensure
+//     strict cluster membership.
+//  4. Discovery (Legacy Fallback): Selects VMIs by creator label and filters by VM name prefix
+//     matching the clusterName.
 //
 // Note: This assumes all VMs in the guest cluster share the same namespace and network configuration.
 // The remote application is responsible for the correctness of the appointed network name;
 // if it's wrong, it could lead to a failure to allocate IPs from the target pool.
-func (m *mutator) findNetwork(lb *lbv1.LoadBalancer, clusterName string) (string, error) {
-	// 1 & 2: Check annotations first
-	if net := lb.Annotations[utils.AnnotationKeyGuestClusterNetworkNameOnLB]; net != "" {
+func (m *mutator) findNetwork(lb *lbv1.LoadBalancer) (string, error) {
+	// The cluster-name is a mandatory precondition for all discovery and resolution tiers.
+	// Proceeding without it risks misidentifying the guest cluster or leaking IP resources.
+	clusterName := lb.Annotations[utils.AnnotationKeyCluster]
+	if clusterName == "" {
+		// We avoid returning an error here to prevent "brutally" breaking the remote
+		// side's creation request. This ensures the LoadBalancer object is admitted
+		// so that the downstream IPAM controller can process it and guest cluster could emit a
+		// descriptive Kubernetes Event.
+		logrus.WithFields(logrus.Fields{
+			"namespace": lb.Namespace,
+			"name":      lb.Name,
+		}).Warnf("findNetwork early exit: missing essential cluster-name annotation %s; return empty network name", utils.AnnotationKeyCluster)
+		return "", nil
+	}
+
+	// when cloud-provider-harvester has already patched the network, respect it
+	if net := lb.Annotations[utils.AnnotationKeyNetwork]; net != "" {
 		return net, nil
 	}
+
+	// when cloud-provider-harvester has already patched the management network, respect it
 	if net := lb.Annotations[utils.AnnotationKeyGuestClusterManagementNetworkOnLB]; net != "" {
 		return net, nil
 	}
 
-	// 3: Modern Discovery (Label-based)
-	// Use both creator and cluster-name to match, it ensures the vm is belonging to this cluster
-	modernSelector := utils.NewGuestClusterNameAndCreatorNameSelecotr(clusterName)
-	modernVMIs, err := m.vmiCache.List(lb.Namespace, modernSelector)
+	// use cluster-name to match
+	clusterNameSelector := utils.NewGuestClusterNameSelector(clusterName)
+	modernVMIs, err := m.vmiCache.List(lb.Namespace, clusterNameSelector)
 	if err != nil {
-		return "", fmt.Errorf("list vmis with modern selector failed: %w", err)
+		return "", fmt.Errorf("list vmis with guest cluster name %s selector failed: %w", clusterName, err)
 	}
 	if name, found := getFirstMultusNetworkName(modernVMIs); found {
 		return name, nil
 	}
 
-	// 4: Legacy Fallback (label + name prefix)
-	// It selects vm by creator label, and then match by vm name prefix
-	legacySelector := utils.NewGuestClusterCreatorSelecotr()
-	legacyVMIs, err := m.vmiCache.List(lb.Namespace, legacySelector)
+	// use creator to match
+	// might get a wrong network when there are multi guest clusters on a same namesapce
+	// keep it for backward compatibility
+	creatorSelector := utils.NewGuestClusterCreatorSelector()
+	legacyVMIs, err := m.vmiCache.List(lb.Namespace, creatorSelector)
 	if err != nil {
-		return "", fmt.Errorf("list vmis with legacy selector failed: %w", err)
+		return "", fmt.Errorf("list vmis with creator selector failed: %w", err)
 	}
 	if name, found := findNetworkByLegacyNameMatch(legacyVMIs, clusterName); found {
 		return name, nil
@@ -256,10 +283,21 @@ func (m *mutator) findNetwork(lb *lbv1.LoadBalancer, clusterName string) (string
 // getFirstMultusNetworkName searches a list of VMIs and returns the first Multus network name found.
 func getFirstMultusNetworkName(vmis []*kubevirtv1.VirtualMachineInstance) (string, bool) {
 	for _, vmi := range vmis {
-		for _, network := range vmi.Spec.Networks {
-			if network.Multus != nil {
-				return network.Multus.NetworkName, true
-			}
+		if name, found := getFirstMultusNetworkNameFromVMI(vmi); found {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+func getFirstMultusNetworkNameFromVMI(vmi *kubevirtv1.VirtualMachineInstance) (string, bool) {
+	if vmi == nil {
+		return "", false
+	}
+	for _, network := range vmi.Spec.Networks {
+		// Ensure Multus is configured and the NetworkName is actually populated
+		if network.Multus != nil && network.Multus.NetworkName != "" {
+			return network.Multus.NetworkName, true
 		}
 	}
 	return "", false
@@ -268,9 +306,9 @@ func getFirstMultusNetworkName(vmis []*kubevirtv1.VirtualMachineInstance) (strin
 // findNetworkByLegacyNameMatch filters VMIs by name prefix and returns the first Multus network name found.
 func findNetworkByLegacyNameMatch(vmis []*kubevirtv1.VirtualMachineInstance, clusterName string) (string, bool) {
 	for _, vmi := range vmis {
+		// return the first multus network of the first vmi whose name starts with the cluster name
 		if strings.HasPrefix(vmi.Name, clusterName) {
-			// Reuse the spec-traversal helper for consistency
-			if name, found := getFirstMultusNetworkName([]*kubevirtv1.VirtualMachineInstance{vmi}); found {
+			if name, found := getFirstMultusNetworkNameFromVMI(vmi); found {
 				return name, true
 			}
 		}

--- a/pkg/webhook/loadbalancer/mutator.go
+++ b/pkg/webhook/loadbalancer/mutator.go
@@ -214,27 +214,36 @@ func (m *mutator) findProject(namespace string) (string, error) {
 
 // findNetwork identifies the target network for the guest cluster.
 //
-// Precondition:
-// The LoadBalancer must contain the cluster-name annotation (utils.AnnotationKeyCluster).
-// If missing, the function exits early with an empty result as discovery is impossible.
-//
 // Priority-based Resolution:
 //  1. Explicit Network: Uses the value from AnnotationKeyNetwork if present.
 //  2. Management Network: Uses the value from AnnotationKeyGuestClusterManagementNetworkOnLB if present.
-//  3. Discovery (Modern): Matches VMIs by creator cluster-name labels to ensure
+//
+// The following two approaches depend on the cluster-name annotation (utils.AnnotationKeyCluster).
+// If it's missing, the function exits early with an empty result as discovery is impossible.
+//
+//  3. Discovery via cluster-name: Matches VMIs by cluster-name labels to ensure
 //     strict cluster membership.
-//  4. Discovery (Legacy Fallback): Selects VMIs by creator label and filters by VM name prefix
+//  4. Discovery via creator (fallback): Selects VMIs by creator label and filters by VM name prefix
 //     matching the clusterName.
 //
 // Note: This assumes all VMs in the guest cluster share the same namespace and network configuration.
 // The remote application is responsible for the correctness of the appointed network name;
 // if it's wrong, it could lead to a failure to allocate IPs from the target pool.
 func (m *mutator) findNetwork(lb *lbv1.LoadBalancer) (string, error) {
-	// The cluster-name is a mandatory precondition for all discovery and resolution tiers.
-	// Proceeding without it risks misidentifying the guest cluster or leaking IP resources.
+	// when cloud-provider-harvester has already patched lb with network annotation, respect it
+	if net := lb.Annotations[utils.AnnotationKeyNetwork]; net != "" {
+		return net, nil
+	}
+
+	// when cloud-provider-harvester has already patched the management network, respect it
+	if net := lb.Annotations[utils.AnnotationKeyGuestClusterManagementNetworkOnLB]; net != "" {
+		return net, nil
+	}
+
+	// The cluster-name is a mandatory precondition for cluster-name & creator type discovery
 	clusterName := lb.Annotations[utils.AnnotationKeyCluster]
 	if clusterName == "" {
-		// We avoid returning an error here to prevent "brutally" breaking the remote
+		// Avoid returning an error here to prevent "brutally" breaking the remote
 		// side's creation request. This ensures the LoadBalancer object is admitted
 		// so that the downstream IPAM controller can process it and guest cluster could emit a
 		// descriptive Kubernetes Event.
@@ -245,35 +254,25 @@ func (m *mutator) findNetwork(lb *lbv1.LoadBalancer) (string, error) {
 		return "", nil
 	}
 
-	// when cloud-provider-harvester has already patched the network, respect it
-	if net := lb.Annotations[utils.AnnotationKeyNetwork]; net != "" {
-		return net, nil
-	}
-
-	// when cloud-provider-harvester has already patched the management network, respect it
-	if net := lb.Annotations[utils.AnnotationKeyGuestClusterManagementNetworkOnLB]; net != "" {
-		return net, nil
-	}
-
 	// use cluster-name to match
 	clusterNameSelector := utils.NewGuestClusterNameSelector(clusterName)
-	modernVMIs, err := m.vmiCache.List(lb.Namespace, clusterNameSelector)
+	cnVMIs, err := m.vmiCache.List(lb.Namespace, clusterNameSelector)
 	if err != nil {
 		return "", fmt.Errorf("list vmis with guest cluster name %s selector failed: %w", clusterName, err)
 	}
-	if name, found := getFirstMultusNetworkName(modernVMIs); found {
+	if name, found := getFirstMultusNetworkName(cnVMIs); found {
 		return name, nil
 	}
 
 	// use creator to match
-	// might get a wrong network when there are multi guest clusters on a same namesapce
+	// might get a wrong network when there are multi guest clusters on a same namespace
 	// keep it for backward compatibility
 	creatorSelector := utils.NewGuestClusterCreatorSelector()
-	legacyVMIs, err := m.vmiCache.List(lb.Namespace, creatorSelector)
+	creatorVMIs, err := m.vmiCache.List(lb.Namespace, creatorSelector)
 	if err != nil {
 		return "", fmt.Errorf("list vmis with creator selector failed: %w", err)
 	}
-	if name, found := findNetworkByLegacyNameMatch(legacyVMIs, clusterName); found {
+	if name, found := findNetworkByLegacyNameMatch(creatorVMIs, clusterName); found {
 		return name, nil
 	}
 

--- a/pkg/webhook/loadbalancer/mutator.go
+++ b/pkg/webhook/loadbalancer/mutator.go
@@ -8,8 +8,8 @@ import (
 	rancherproject "github.com/rancher/rancher/pkg/project"
 	ctlcorev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	lbv1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
 	ctlkubevirtv1 "github.com/harvester/harvester-load-balancer/pkg/generated/controllers/kubevirt.io/v1"
@@ -140,18 +140,26 @@ func (m *mutator) getAnnotationsPatchVM(lb *lbv1.LoadBalancer) (admission.Patch,
 
 // for Cluster type LB
 func (m *mutator) getAnnotationsPatchCluster(lb *lbv1.LoadBalancer) (admission.Patch, error) {
+	if lb.Spec.WorkloadType != lbv1.Cluster {
+		return nil, nil
+	}
+
 	project, err := m.findProject(lb.Namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	var network string
-	if lb.Spec.WorkloadType == lbv1.Cluster && lb.Annotations != nil && lb.Annotations[utils.AnnotationKeyCluster] != "" {
-		network, err = m.findNetwork(lb.Namespace, lb.Annotations[utils.AnnotationKeyCluster])
-		if err != nil {
-			return nil, err
-		}
+	network, err := m.findNetwork(lb, lb.Annotations[utils.AnnotationKeyCluster])
+	if err != nil {
+		return nil, err
 	}
+
+	// per the carried annotation like `loadbalancer.harvesterhci.io/cluster: gc1`
+	// additional annotations are mutated
+	//
+	//   loadbalancer.harvesterhci.io/namespace: default
+	//   loadbalancer.harvesterhci.io/network: default/vm-untag
+	//   loadbalancer.harvesterhci.io/project: c-q4xz6/p-6vvfz
 
 	annotations := lb.Annotations
 	if annotations == nil {
@@ -198,31 +206,74 @@ func (m *mutator) findProject(namespace string) (string, error) {
 		return "", fmt.Errorf("get namespace %s failed, error: %w", namespace, err)
 	}
 
+	// the valid format is like `c-q4xz6:p-6vvfz`
 	return strings.Replace(ns.Annotations[rancherproject.ProjectIDAnn], ":", "/", 1), nil
 }
 
-// Find the first network where the guest cluster is running
-// We assume that all the virtual machines composed the guest cluster are running in the same namespace and
-// have the same network configuration.
-func (m *mutator) findNetwork(namespace, clusterName string) (string, error) {
-	// list all the vmi instance in the same namespace of the load balancer
-	vmis, err := m.vmiCache.List(namespace, labels.Set(map[string]string{
-		utils.LabelKeyHarvesterCreator: utils.GuestClusterHarvesterNodeDriver,
-	}).AsSelector())
-	if err != nil {
-		return "", fmt.Errorf("list vmis failed, error: %w", err)
+// findNetwork identifies the target network for the guest cluster using a priority-based approach:
+// 1. Explicit Network: AnnotationKeyGuestClusterNetworkNameOnLB
+// 2. Management Network: AnnotationKeyGuestClusterManagementNetworkOnLB
+// 3. Discovery (New): Use both creator and cluster-name to match, it ensures the vm is belonging to this cluster.
+// 4. Discovery (Legacy): It selects vm by creator label, and then match by vm name prefix.
+//
+// Note: This assumes all VMs in the guest cluster share the same namespace and network configuration.
+// The remote application is responsible for the correctness of the appointed network name;
+// if it's wrong, it could lead to a failure to allocate IPs from the target pool.
+func (m *mutator) findNetwork(lb *lbv1.LoadBalancer, clusterName string) (string, error) {
+	// 1 & 2: Check annotations first
+	if net := lb.Annotations[utils.AnnotationKeyGuestClusterNetworkNameOnLB]; net != "" {
+		return net, nil
+	}
+	if net := lb.Annotations[utils.AnnotationKeyGuestClusterManagementNetworkOnLB]; net != "" {
+		return net, nil
 	}
 
-	// find the first network of the first vmi whose name starts with the cluster name
-	for _, vmi := range vmis {
-		if strings.HasPrefix(vmi.Name, clusterName) {
-			for _, network := range vmi.Spec.Networks {
-				if network.Multus != nil {
-					return network.Multus.NetworkName, nil
-				}
-			}
-		}
+	// 3: Modern Discovery (Label-based)
+	// Use both creator and cluster-name to match, it ensures the vm is belonging to this cluster
+	modernSelector := utils.NewGuestClusterNameAndCreatorNameSelecotr(clusterName)
+	modernVMIs, err := m.vmiCache.List(lb.Namespace, modernSelector)
+	if err != nil {
+		return "", fmt.Errorf("list vmis with modern selector failed: %w", err)
+	}
+	if name, found := getFirstMultusNetworkName(modernVMIs); found {
+		return name, nil
+	}
+
+	// 4: Legacy Fallback (label + name prefix)
+	// It selects vm by creator label, and then match by vm name prefix
+	legacySelector := utils.NewGuestClusterCreatorSelecotr()
+	legacyVMIs, err := m.vmiCache.List(lb.Namespace, legacySelector)
+	if err != nil {
+		return "", fmt.Errorf("list vmis with legacy selector failed: %w", err)
+	}
+	if name, found := findNetworkByLegacyNameMatch(legacyVMIs, clusterName); found {
+		return name, nil
 	}
 
 	return "", nil
+}
+
+// getFirstMultusNetworkName searches a list of VMIs and returns the first Multus network name found.
+func getFirstMultusNetworkName(vmis []*kubevirtv1.VirtualMachineInstance) (string, bool) {
+	for _, vmi := range vmis {
+		for _, network := range vmi.Spec.Networks {
+			if network.Multus != nil {
+				return network.Multus.NetworkName, true
+			}
+		}
+	}
+	return "", false
+}
+
+// findNetworkByLegacyNameMatch filters VMIs by name prefix and returns the first Multus network name found.
+func findNetworkByLegacyNameMatch(vmis []*kubevirtv1.VirtualMachineInstance, clusterName string) (string, bool) {
+	for _, vmi := range vmis {
+		if strings.HasPrefix(vmi.Name, clusterName) {
+			// Reuse the spec-traversal helper for consistency
+			if name, found := getFirstMultusNetworkName([]*kubevirtv1.VirtualMachineInstance{vmi}); found {
+				return name, true
+			}
+		}
+	}
+	return "", false
 }

--- a/pkg/webhook/loadbalancer/mutator_test.go
+++ b/pkg/webhook/loadbalancer/mutator_test.go
@@ -155,7 +155,21 @@ func TestFindNetwork(t *testing.T) {
 		wantNetworkName string
 	}{
 		{
-			name: "Priority 1: Explicit Network exists",
+			name: "Found (priority 1): Use AnnotationKeyNetwork even when cluster-name is empty",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "empty-cluster-name",
+					Annotations: map[string]string{
+						utils.AnnotationKeyCluster: "",
+						utils.AnnotationKeyNetwork: "custom/explicit-net",
+					},
+				},
+			},
+			wantNetworkName: "custom/explicit-net",
+		},
+		{
+			name: "Found (priority 1): Use AnnotationKeyNetwork",
 			lb: &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -168,27 +182,12 @@ func TestFindNetwork(t *testing.T) {
 			wantNetworkName: "custom/explicit-net",
 		},
 		{
-			name: "Priority 1: Explicit Network exists but no cluster-name, returns empty",
-			lb: &lbv1.LoadBalancer{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "empty-cluster-name",
-					Annotations: map[string]string{
-						utils.AnnotationKeyCluster: "",
-						utils.AnnotationKeyNetwork: "custom/explicit-net",
-					},
-				},
-			},
-			wantNetworkName: "", // cluster-name is the precondition
-		},
-		{
-			name: "Priority 2: Fallthrough when Priority 1 is empty string",
+			name: "Found (priority 2): Use AnnotationKeyGuestClusterManagementNetworkOnLB when AnnotationKeyNetwork is empty",
 			lb: &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Annotations: map[string]string{
-						utils.AnnotationKeyCluster:                           "any-cluster",
-						utils.AnnotationKeyNetwork:                           "",
+						utils.AnnotationKeyNetwork:                           "", // empty value is skipped
 						utils.AnnotationKeyGuestClusterManagementNetworkOnLB: "mgmt/mgmt-net",
 					},
 				},
@@ -196,7 +195,7 @@ func TestFindNetwork(t *testing.T) {
 			wantNetworkName: "mgmt/mgmt-net",
 		},
 		{
-			name: "Step 3: Modern Discovery (Label-based)",
+			name: "Found (priority 3): via cluster-name label to match VMI",
 			lb: &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -208,7 +207,7 @@ func TestFindNetwork(t *testing.T) {
 			wantNetworkName: "default/modern-net",
 		},
 		{
-			name: "Step 4: Legacy Discovery (Prefix-based fallback)",
+			name: "Found (priority 4): (fallback) via creator + prefix to match VMI",
 			lb: &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -220,7 +219,7 @@ func TestFindNetwork(t *testing.T) {
 			wantNetworkName: "default/mgmt-untagged",
 		},
 		{
-			name: "Namespace Mismatch: Valid cluster-name but wrong namespace returns empty",
+			name: "Not found (priority 3, 4): Valid cluster-name but wrong namespace returns empty",
 			lb: &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "wrong-namespace",
@@ -232,25 +231,12 @@ func TestFindNetwork(t *testing.T) {
 			wantNetworkName: "",
 		},
 		{
-			name: "No Match: Correct namespace but wrong cluster-name returns empty",
+			name: "Not found (priority 3, 4): Correct namespace but wrong cluster-name returns empty",
 			lb: &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Annotations: map[string]string{
 						utils.AnnotationKeyCluster: "non-existent-cluster",
-					},
-				},
-			},
-			wantNetworkName: "",
-		},
-		{
-			name: "No Match: cluster-name is missing then returns empty",
-			lb: &lbv1.LoadBalancer{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "lb-without-cluster-name-annotation",
-					Annotations: map[string]string{
-						utils.AnnotationKeyCluster: "",
 					},
 				},
 			},

--- a/pkg/webhook/loadbalancer/mutator_test.go
+++ b/pkg/webhook/loadbalancer/mutator_test.go
@@ -17,8 +17,8 @@ import (
 
 const mutatorCaseDirectory = "./testdata/mutator/"
 
-// TestFindProject tests the function findProject
-func TestFindProject(t *testing.T) {
+// Test_findProject tests the function findProject
+func Test_findProject(t *testing.T) {
 	namespaces, err := utils.ParseFromFile(filepath.Join(mutatorCaseDirectory + "namespace.yaml"))
 	if err != nil {
 		t.Error(err)
@@ -57,6 +57,7 @@ func TestFindProject(t *testing.T) {
 					Name:      "test",
 				},
 				Spec: lbv1.LoadBalancerSpec{
+					WorkloadType: lbv1.VM,
 					Listeners: []lbv1.Listener{
 						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
 						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
@@ -75,6 +76,7 @@ func TestFindProject(t *testing.T) {
 					Name:      "test",
 				},
 				Spec: lbv1.LoadBalancerSpec{
+					WorkloadType: lbv1.VM,
 					Listeners: []lbv1.Listener{
 						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
 						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
@@ -93,6 +95,7 @@ func TestFindProject(t *testing.T) {
 					Name:      "test",
 				},
 				Spec: lbv1.LoadBalancerSpec{
+					WorkloadType: lbv1.VM,
 					Listeners: []lbv1.Listener{
 						{Name: "a", BackendPort: 80, Protocol: corev1.ProtocolTCP},
 						{Name: "b", BackendPort: 32, Protocol: corev1.ProtocolUDP},
@@ -130,11 +133,11 @@ func TestFindProject(t *testing.T) {
 	}
 }
 
-// TestFindNetwork tests the function findNetwork
-func TestFindNetwork(t *testing.T) {
-	vmis, err := utils.ParseFromFile(filepath.Join(mutatorCaseDirectory + "vmi.yaml"))
+// Test_findNetwork tests the function findNetwork
+func Test_findNetwork(t *testing.T) {
+	vmis, err := utils.ParseFromFile(filepath.Join(mutatorCaseDirectory, "vmi.yaml"))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	clientset := fake.NewSimpleClientset(vmis...)
@@ -144,23 +147,90 @@ func TestFindNetwork(t *testing.T) {
 	}
 
 	tests := []struct {
-		namespace       string
+		name            string
+		lb              *lbv1.LoadBalancer
 		clusterName     string
 		wantNetworkName string
 	}{
 		{
-			namespace:       "default",
-			clusterName:     "rke2",
+			name: "Priority 1: Explicit Network exists",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Annotations: map[string]string{
+						utils.AnnotationKeyGuestClusterNetworkNameOnLB: "custom/explicit-net",
+					},
+				},
+			},
+			clusterName:     "any-cluster",
+			wantNetworkName: "custom/explicit-net",
+		},
+		{
+			name: "Priority 2: Fallthrough when Priority 1 is empty string",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Annotations: map[string]string{
+						utils.AnnotationKeyGuestClusterNetworkNameOnLB:       "",
+						utils.AnnotationKeyGuestClusterManagementNetworkOnLB: "mgmt/mgmt-net",
+					},
+				},
+			},
+			clusterName:     "any-cluster",
+			wantNetworkName: "mgmt/mgmt-net",
+		},
+		{
+			name: "Step 3: Modern Discovery (Label-based)",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+			},
+			clusterName:     "modern-cluster", // Matches guestcluster.harvesterhci.io/name label
+			wantNetworkName: "default/modern-net",
+		},
+		{
+			name: "Step 4: Legacy Discovery (Prefix-based fallback)",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+			},
+			clusterName:     "rke2-pool1", // Matches name prefix of legacy VMI
 			wantNetworkName: "default/mgmt-untagged",
+		},
+		{
+			name: "Namespace Mismatch: Valid clusterName but wrong namespace returns empty",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "wrong-namespace",
+				},
+			},
+			clusterName:     "modern-cluster",
+			wantNetworkName: "",
+		},
+		{
+			name: "No Match: Correct namespace but wrong clusterName returns empty",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+			},
+			clusterName:     "non-existent-cluster",
+			wantNetworkName: "",
 		},
 	}
 
-	for _, test := range tests {
-		if network, err := m.findNetwork(test.namespace, test.clusterName); err != nil {
-			t.Error(err)
-		} else if network != test.wantNetworkName {
-			t.Errorf("want network %s through namespace %s and cluster %s, got %s",
-				test.wantNetworkName, test.namespace, test.clusterName, network)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network, err := m.findNetwork(tt.lb, tt.clusterName)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if network != tt.wantNetworkName {
+				t.Errorf("findNetwork() got = %q, want %q", network, tt.wantNetworkName)
+			}
+		})
 	}
 }

--- a/pkg/webhook/loadbalancer/mutator_test.go
+++ b/pkg/webhook/loadbalancer/mutator_test.go
@@ -15,10 +15,12 @@ import (
 	"github.com/harvester/harvester-load-balancer/pkg/utils/fakeclients"
 )
 
-const mutatorCaseDirectory = "./testdata/mutator/"
+const (
+	mutatorCaseDirectory = "./testdata/mutator/"
+)
 
-// Test_findProject tests the function findProject
-func Test_findProject(t *testing.T) {
+// TestFindProject tests the function findProject
+func TestFindProject(t *testing.T) {
 	namespaces, err := utils.ParseFromFile(filepath.Join(mutatorCaseDirectory + "namespace.yaml"))
 	if err != nil {
 		t.Error(err)
@@ -133,8 +135,9 @@ func Test_findProject(t *testing.T) {
 	}
 }
 
-// Test_findNetwork tests the function findNetwork
-func Test_findNetwork(t *testing.T) {
+// TestFindNetwork tests the function findNetwork
+func TestFindNetwork(t *testing.T) {
+
 	vmis, err := utils.ParseFromFile(filepath.Join(mutatorCaseDirectory, "vmi.yaml"))
 	if err != nil {
 		t.Fatal(err)
@@ -149,7 +152,6 @@ func Test_findNetwork(t *testing.T) {
 	tests := []struct {
 		name            string
 		lb              *lbv1.LoadBalancer
-		clusterName     string
 		wantNetworkName string
 	}{
 		{
@@ -158,12 +160,26 @@ func Test_findNetwork(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Annotations: map[string]string{
-						utils.AnnotationKeyGuestClusterNetworkNameOnLB: "custom/explicit-net",
+						utils.AnnotationKeyCluster: "any-cluster",
+						utils.AnnotationKeyNetwork: "custom/explicit-net",
 					},
 				},
 			},
-			clusterName:     "any-cluster",
 			wantNetworkName: "custom/explicit-net",
+		},
+		{
+			name: "Priority 1: Explicit Network exists but no cluster-name, returns empty",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "empty-cluster-name",
+					Annotations: map[string]string{
+						utils.AnnotationKeyCluster: "",
+						utils.AnnotationKeyNetwork: "custom/explicit-net",
+					},
+				},
+			},
+			wantNetworkName: "", // cluster-name is the precondition
 		},
 		{
 			name: "Priority 2: Fallthrough when Priority 1 is empty string",
@@ -171,12 +187,12 @@ func Test_findNetwork(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Annotations: map[string]string{
-						utils.AnnotationKeyGuestClusterNetworkNameOnLB:       "",
+						utils.AnnotationKeyCluster:                           "any-cluster",
+						utils.AnnotationKeyNetwork:                           "",
 						utils.AnnotationKeyGuestClusterManagementNetworkOnLB: "mgmt/mgmt-net",
 					},
 				},
 			},
-			clusterName:     "any-cluster",
 			wantNetworkName: "mgmt/mgmt-net",
 		},
 		{
@@ -184,9 +200,11 @@ func Test_findNetwork(t *testing.T) {
 			lb: &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
+					Annotations: map[string]string{
+						utils.AnnotationKeyCluster: "modern-cluster",
+					},
 				},
 			},
-			clusterName:     "modern-cluster", // Matches guestcluster.harvesterhci.io/name label
 			wantNetworkName: "default/modern-net",
 		},
 		{
@@ -194,36 +212,55 @@ func Test_findNetwork(t *testing.T) {
 			lb: &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
+					Annotations: map[string]string{
+						utils.AnnotationKeyCluster: "rke2-pool1",
+					},
 				},
 			},
-			clusterName:     "rke2-pool1", // Matches name prefix of legacy VMI
 			wantNetworkName: "default/mgmt-untagged",
 		},
 		{
-			name: "Namespace Mismatch: Valid clusterName but wrong namespace returns empty",
+			name: "Namespace Mismatch: Valid cluster-name but wrong namespace returns empty",
 			lb: &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "wrong-namespace",
+					Annotations: map[string]string{
+						utils.AnnotationKeyCluster: "modern-cluster",
+					},
 				},
 			},
-			clusterName:     "modern-cluster",
 			wantNetworkName: "",
 		},
 		{
-			name: "No Match: Correct namespace but wrong clusterName returns empty",
+			name: "No Match: Correct namespace but wrong cluster-name returns empty",
 			lb: &lbv1.LoadBalancer{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
+					Annotations: map[string]string{
+						utils.AnnotationKeyCluster: "non-existent-cluster",
+					},
 				},
 			},
-			clusterName:     "non-existent-cluster",
+			wantNetworkName: "",
+		},
+		{
+			name: "No Match: cluster-name is missing then returns empty",
+			lb: &lbv1.LoadBalancer{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "lb-without-cluster-name-annotation",
+					Annotations: map[string]string{
+						utils.AnnotationKeyCluster: "",
+					},
+				},
+			},
 			wantNetworkName: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			network, err := m.findNetwork(tt.lb, tt.clusterName)
+			network, err := m.findNetwork(tt.lb)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return

--- a/pkg/webhook/loadbalancer/testdata/mutator/vmi.yaml
+++ b/pkg/webhook/loadbalancer/testdata/mutator/vmi.yaml
@@ -1,3 +1,4 @@
+# Legacy VMI: No cluster label, matches only via Step 4 (Name Prefix)
 apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
@@ -10,6 +11,21 @@ spec:
     - multus:
         networkName: default/mgmt-untagged
       name: nic-0
+---
+# Modern VMI: Matches via Step 3 (Creator + ClusterName Labels)
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstance
+metadata:
+    name: any-vmi-name
+    namespace: default
+    labels:
+        harvesterhci.io/creator: "docker-machine-driver-harvester"
+        guestcluster.harvesterhci.io/name: "modern-cluster"
+spec:
+    networks:
+        - multus:
+                networkName: default/modern-net
+          name: nic-0
 ---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance

--- a/pkg/webhook/loadbalancer/testdata/mutator/vmi.yaml
+++ b/pkg/webhook/loadbalancer/testdata/mutator/vmi.yaml
@@ -1,4 +1,4 @@
-# Legacy VMI: No cluster label, matches only via Step 4 (Name Prefix)
+# matched via creator and name prefix
 apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
@@ -12,7 +12,7 @@ spec:
         networkName: default/mgmt-untagged
       name: nic-0
 ---
-# Modern VMI: Matches via Step 3 (Creator + ClusterName Labels)
+# matched via cluster-name
 apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:

--- a/pkg/webhook/loadbalancer/testdata/mutator/vmi.yaml
+++ b/pkg/webhook/loadbalancer/testdata/mutator/vmi.yaml
@@ -16,16 +16,16 @@ spec:
 apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
-    name: any-vmi-name
-    namespace: default
-    labels:
-        harvesterhci.io/creator: "docker-machine-driver-harvester"
-        guestcluster.harvesterhci.io/name: "modern-cluster"
+  name: any-vmi-name
+  namespace: default
+  labels:
+    harvesterhci.io/creator: "docker-machine-driver-harvester"
+    guestcluster.harvesterhci.io/name: "modern-cluster"
 spec:
-    networks:
-        - multus:
-                networkName: default/modern-net
-          name: nic-0
+  networks:
+    - multus:
+        networkName: default/modern-net
+      name: nic-0
 ---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance

--- a/pkg/webhook/loadbalancer/validator.go
+++ b/pkg/webhook/loadbalancer/validator.go
@@ -246,7 +246,7 @@ func (v *validator) checkGuestClusterIsOnRemove(lb *lbv1.LoadBalancer) error {
 	// The guest cluster name is required because multiple guest clusters may coexist in a single namespace
 	// Note: Only Rancher Manager-managed guest clusters follow this labeling convention
 	// custom or manual guest clusters may not adhere to this requirement
-	selector := utils.NewGuestClusterNameAndCreatorNameSelecotr(gcName)
+	selector := utils.NewGuestClusterNameAndCreatorNameSelector(gcName)
 	vms, err := v.vmCache.List(lb.Namespace, selector)
 	if err != nil {
 		return fmt.Errorf("list vm from %s failed, error: %w", lb.Namespace, err)

--- a/pkg/webhook/loadbalancer/validator.go
+++ b/pkg/webhook/loadbalancer/validator.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sirupsen/logrus"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	lbv1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
@@ -247,10 +246,7 @@ func (v *validator) checkGuestClusterIsOnRemove(lb *lbv1.LoadBalancer) error {
 	// The guest cluster name is required because multiple guest clusters may coexist in a single namespace
 	// Note: Only Rancher Manager-managed guest clusters follow this labeling convention
 	// custom or manual guest clusters may not adhere to this requirement
-	selector := labels.Set(map[string]string{
-		utils.LabelKeyHarvesterCreator:     utils.GuestClusterHarvesterNodeDriver,
-		utils.LabelKeyGuestClusterNameOnVM: gcName,
-	}).AsSelector()
+	selector := utils.NewGuestClusterNameAndCreatorNameSelecotr(gcName)
 	vms, err := v.vmCache.List(lb.Namespace, selector)
 	if err != nil {
 		return fmt.Errorf("list vm from %s failed, error: %w", lb.Namespace, err)


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

When guest-cluster is running on multi-network mode( node/vm has mutli multus networks), the loadbalancer IPPool selection is unpredicted.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Besides the enhancment PR https://github.com/harvester/cloud-provider-harvester/pull/74, we also need this PR, as pair PR, to support the appointed network by cloud-provider-harvester, to handle the multi-network scenario.

Guest cluster could:

(1) Don't set any network related annotation, loadbalancer looks for the first multus network (it could be wrong, on multi-network scenario), it tries to match cluster-name label first, then creator label

(2) Set `cloudprovider.harvesterhci.io/managementNetwork` via HCP `--management-network` flag

(3) Users set `cloudprovider.harvesterhci.io/network` on guest LB type service when create service, then HCP converts it into `loadbalancer.harvesterhci.io/network` annotation to the LB object via the HCP->loadbalancer API call. Loadbalancer respects this annotation.

When (2)(3) are both existing, (3) is in higher priority than (2)

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10381
https://github.com/harvester/harvester/issues/10068

#### Test plan:
<!-- Describe the test plan by steps. -->

https://github.com/harvester/load-balancer-harvester/pull/103#issuecomment-4729041468

#### Additional documentation or context
