### PR TITLE
fix: enhance network annotation handling in getAnnotationsPatchCluster

### DIFF
--- a/pkg/webhook/loadbalancer/mutator.go
+++ b/pkg/webhook/loadbalancer/mutator.go
@@ -146,10 +146,14 @@ func (m *mutator) getAnnotationsPatchCluster(lb *lbv1.LoadBalancer) (admission.P
 	}
 
 	var network string
-	if lb.Spec.WorkloadType == lbv1.Cluster && lb.Annotations != nil && lb.Annotations[utils.AnnotationKeyCluster] != "" {
-		network, err = m.findNetwork(lb.Namespace, lb.Annotations[utils.AnnotationKeyCluster])
-		if err != nil {
-			return nil, err
+	if _, ok := lb.Annotations[utils.AnnotationKeyNetwork]; ok {
+		network = lb.Annotations[utils.AnnotationKeyNetwork]
+	} else {
+		if lb.Annotations != nil && lb.Annotations[utils.AnnotationKeyCluster] != "" {
+			network, err = m.findNetwork(lb.Namespace, lb.Annotations[utils.AnnotationKeyCluster])
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Aviod mutator from modifying the network annotation when guest cluster type load balancer already has the value

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
**In cluster type LB**, current mutator always modifies the network value even the annotation already has the value. 

#### Solution:
Skip modifying network when the annotation AnnotationKeyNetwork has the value.

#### Related Issue(s):

https://github.com/harvester/harvester/issues/5486

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
