### PR TITLE
Update VM type ippool selection

### DIFF
--- a/pkg/controller/loadbalancer/controller.go
+++ b/pkg/controller/loadbalancer/controller.go
@@ -356,6 +356,28 @@ func (h *Handler) requestIP(lb *lbv1.LoadBalancer, pool string) (*lbv1.Allocated
 	}, nil
 }
 
+func updateVMTypeSelector(lb *lbv1.LoadBalancer, r *ipam.Requirement) {
+	// empty WorkloadType defaults to VM type
+	if lb.Spec.WorkloadType != lbv1.VM && lb.Spec.WorkloadType != "" {
+		return
+	}
+	// VM type lb does not have concept of Project, Cluster, set them to AllSelector if empty
+	// this does not rely on the webhook to update them to AllSelector
+	if r.Project == "" {
+		r.Project = ipam.AllSelector
+	}
+	if r.Cluster == "" {
+		r.Cluster = ipam.AllSelector
+	}
+	// if user does not explicitly set a network annotation
+	// then it equals to any network
+	// note that, on UI, for VM type LB, it can manually select any IPPool
+	// this will be enforced in the future
+	if r.Network == "" {
+		r.Network = ipam.AllSelector
+	}
+}
+
 func (h *Handler) selectIPPool(lb *lbv1.LoadBalancer) (string, error) {
 	r := &ipam.Requirement{
 		Network:   lb.Annotations[utils.AnnotationKeyNetwork],
@@ -366,6 +388,9 @@ func (h *Handler) selectIPPool(lb *lbv1.LoadBalancer) (string, error) {
 	if r.Namespace == "" {
 		r.Namespace = lb.Namespace
 	}
+
+	updateVMTypeSelector(lb, r)
+
 	pool, err := ipam.NewSelector(h.ipPoolCache).Select(r, false)
 	if err != nil {
 		return "", fmt.Errorf("%w with selector, error: %w", errNoMatchedIPPool, err)

--- a/pkg/ipam/ippool.go
+++ b/pkg/ipam/ippool.go
@@ -10,6 +10,7 @@ func IsGlobalIPPool(pool *lbv1.IPPool) bool {
 }
 
 // a global pool of a specific network
+// if the network is All (could only be passed for VM type LB), then it just checks the IsGlobalIPPool
 func IsGlobalIPPoolOfNetwork(pool *lbv1.IPPool, network string) bool {
-	return pool.Spec.Selector.Network == network && IsGlobalIPPool(pool)
+	return (network == All || pool.Spec.Selector.Network == network) && IsGlobalIPPool(pool)
 }

--- a/pkg/ipam/selector.go
+++ b/pkg/ipam/selector.go
@@ -11,6 +11,7 @@ import (
 
 const All = "*"
 const EmptySelector = ""
+const AllSelector = All // use AllSelector instead of All
 
 type Selector struct {
 	ctllbv1.IPPoolCache
@@ -49,7 +50,9 @@ func NewMatcherWithMode(poolSelector lbv1.Selector, looseMode bool) *Matcher {
 }
 
 func (m *Matcher) Matches(r *Requirement) bool {
-	if m.selector.Network != r.Network {
+	// VM type LB does not expose network to user, hence the network is set to All by controller
+	// guest type LB must specify a network, it can't be All
+	if r.Network != All && m.selector.Network != r.Network {
 		return false
 	}
 
@@ -79,7 +82,10 @@ func (s *Selector) Select(r *Requirement, looseMode bool) (*lbv1.IPPool, error) 
 	var priority uint32
 	for _, pool := range pools {
 		if IsGlobalIPPoolOfNetwork(pool, r.Network) {
-			globalPool = pool
+			// take the first one
+			if globalPool == nil {
+				globalPool = pool
+			}
 			continue
 		}
 		// If the priority is not zero, every pool has different priority value.


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

In the past, VM type LB could select a pool automatically.

But after the enforcement of network matching for guest-cluster case https://github.com/harvester/load-balancer-harvester/pull/104, the VM type LB needs to set the network explicitly now.

Due to the fact:

(1) VM type LB could select any pool manually.
(2) It could select one in the past.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

We add a short enhancement:

It keesp VM type LB auto selection working as before.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/10592

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Auto matched
<img width="2516" height="978" alt="image" src="https://github.com/user-attachments/assets/ad84d631-56d5-4f4f-90c7-dc136160d7a9" />

<img width="2824" height="922" alt="image" src="https://github.com/user-attachments/assets/55867b5f-00de-461b-9ad4-90cf91550d00" />

LB auto selects a pool just like manually select.

2. Does not auto matched as namespace mismatch

due to namespace mismatch, the LB can't blindly auto match the pool

<img width="1256" height="660" alt="image" src="https://github.com/user-attachments/assets/afe3e15d-26dc-4e5b-890a-38f13f1e75f3" />

<img width="1310" height="1162" alt="image" src="https://github.com/user-attachments/assets/57ff2e28-44c4-492e-b2b4-252e1551e7ac" />

But user could manually select the pool (it always allows)
<img width="2216" height="686" alt="image" src="https://github.com/user-attachments/assets/25a916bb-9928-4a82-ae72-1f3b73efb7d6" />

<img width="2316" height="806" alt="image" src="https://github.com/user-attachments/assets/cbab924b-7ccc-4ff6-901e-7e3d474e61d1" />

#### Additional documentation or context
