### PR TITLE
Create dummy endpointslices for vm type lb when lb is created

### DIFF
--- a/pkg/lb/servicelb/manager.go
+++ b/pkg/lb/servicelb/manager.go
@@ -526,7 +526,10 @@ func (m *Manager) ensureService(lb *lbv1.LoadBalancer) error {
 		}
 	}
 
-	return nil
+	// Ensure an EndpointSlice to unblock kube-vip.
+	// kube-vip requires non-empty EndpointSlices before writing the VIP back to the Service status,
+	// which would otherwise cause a deadlock.
+	return m.ensureDummyEndpointSliceIfNotExist(lb)
 }
 
 func constructService(cur *corev1.Service, lb *lbv1.LoadBalancer) *corev1.Service {
@@ -675,4 +678,61 @@ func (m *Manager) constructEndpointSliceFromBackendServers(cur *discoveryv1.Endp
 	logrus.Debugln("constructEndpointSliceFromBackendServers: ", eps)
 
 	return eps, nil
+}
+
+func (m *Manager) ensureDummyEndpointSliceIfNotExist(lb *lbv1.LoadBalancer) error {
+	eps, err := m.endpointSliceCache.Get(lb.Namespace, lb.Name)
+	if err == nil {
+		if len(eps.Endpoints) == 0 {
+			return m.ensureDummyEndpoint(lb, eps)
+		}
+		return nil
+	}
+
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("fail to get endpointslice %s/%s, error: %w", lb.Namespace, lb.Name, err)
+	}
+
+	// create a dummy one when it is not found
+	eps = m.constructDummyEndpointSlice(lb)
+	logrus.Debugf("createDummyEndpointslice: %+v", eps)
+
+	_, err = m.endpointSliceClient.Create(eps)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("fail to create dummy endpointslice %s/%s, error: %w", eps.Namespace, eps.Name, err)
+	}
+	return nil
+}
+
+// construct a dummy endpointslice to ensure kube-vip will apply vip first
+func (m *Manager) constructDummyEndpointSlice(lb *lbv1.LoadBalancer) *discoveryv1.EndpointSlice {
+	eps := &discoveryv1.EndpointSlice{}
+	eps.Namespace = lb.Namespace
+	eps.Name = lb.Name
+	eps.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: lb.APIVersion,
+			Kind:       lb.Kind,
+			Name:       lb.Name,
+			UID:        lb.UID,
+		}}
+	eps.Labels = map[string]string{
+		KeyLabel:       utils.ValueTrue,
+		KeyServiceName: lb.Name,
+	}
+	eps.AddressType = discoveryv1.AddressTypeIPv4
+
+	ports := make([]discoveryv1.EndpointPort, 0, len(lb.Spec.Listeners))
+	for i := range lb.Spec.Listeners {
+		port := discoveryv1.EndpointPort{
+			Name:     &(lb.Spec.Listeners[i].Name),
+			Protocol: &(lb.Spec.Listeners[i].Protocol),
+			Port:     &(lb.Spec.Listeners[i].BackendPort),
+		}
+		ports = append(ports, port)
+	}
+	eps.Ports = ports
+	eps.Endpoints = appendDummyEndpoint(eps.Endpoints, lb)
+
+	return eps
 }

--- a/pkg/lb/servicelb/manager_test.go
+++ b/pkg/lb/servicelb/manager_test.go
@@ -3,13 +3,17 @@ package servicelb
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	kubevirtv1 "kubevirt.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
 
 	lbv1 "github.com/harvester/harvester-load-balancer/pkg/apis/loadbalancer.harvesterhci.io/v1beta1"
 	"github.com/harvester/harvester-load-balancer/pkg/generated/clientset/versioned/fake"
+	discoveryv1type "github.com/harvester/harvester-load-balancer/pkg/generated/clientset/versioned/typed/discovery.k8s.io/v1"
 	"github.com/harvester/harvester-load-balancer/pkg/utils/fakeclients"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 )
 
 const (
@@ -179,6 +183,179 @@ func TestGetBackendServer(t *testing.T) {
 			}
 			if ret.GetWithIPAddressBackendServerCount() != tt.withAddressBackendServerCount {
 				t.Errorf("withAddressBackendServerCount, real %v != expected %v", ret.GetWithIPAddressBackendServerCount(), tt.withAddressBackendServerCount)
+			}
+		})
+	}
+}
+
+func TestConstructDummyEndpointSlice(t *testing.T) {
+	portName := "http"
+	proto := corev1.ProtocolTCP
+	var backendPort int32 = 8080
+
+	lb := &lbv1.LoadBalancer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "loadbalancer.harvesterhci.io/v1beta1",
+			Kind:       "LoadBalancer",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lb",
+			Namespace: "default",
+			UID:       "uid-1234",
+		},
+		Spec: lbv1.LoadBalancerSpec{
+			Listeners: []lbv1.Listener{
+				{
+					Name:        portName,
+					Protocol:    proto,
+					BackendPort: backendPort,
+				},
+			},
+		},
+	}
+
+	// lb controller name is unknown
+	m := &Manager{}
+
+	eps := m.constructDummyEndpointSlice(lb)
+
+	if eps.Namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", eps.Namespace)
+	}
+	if eps.Name != "test-lb" {
+		t.Errorf("expected name 'test-lb', got '%s'", eps.Name)
+	}
+	if eps.AddressType != discoveryv1.AddressTypeIPv4 {
+		t.Errorf("expected addressType IPv4, got '%s'", eps.AddressType)
+	}
+
+	// Verify OwnerReference
+	if len(eps.OwnerReferences) != 1 {
+		t.Fatalf("expected 1 OwnerReference, got %d", len(eps.OwnerReferences))
+	}
+	if eps.OwnerReferences[0].Name != lb.Name {
+		t.Errorf("expected OwnerReference name '%s', got '%s'", lb.Name, eps.OwnerReferences[0].Name)
+	}
+	if eps.OwnerReferences[0].UID != lb.UID {
+		t.Errorf("expected OwnerReference UID '%s', got '%s'", lb.UID, eps.OwnerReferences[0].UID)
+	}
+
+	// Verify Labels
+	if svcName := eps.Labels[KeyServiceName]; svcName != lb.Name {
+		t.Errorf("expected service name label '%s', got '%s'", lb.Name, svcName)
+	}
+
+	// Verify Ports
+	if len(eps.Ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(eps.Ports))
+	}
+	if eps.Ports[0].Name == nil || *eps.Ports[0].Name != portName {
+		t.Errorf("expected port name '%s', got '%v'", portName, eps.Ports[0].Name)
+	}
+	if eps.Ports[0].Protocol == nil || *eps.Ports[0].Protocol != proto {
+		t.Errorf("expected protocol '%s', got '%v'", proto, eps.Ports[0].Protocol)
+	}
+	if eps.Ports[0].Port == nil || *eps.Ports[0].Port != backendPort {
+		t.Errorf("expected port '%d', got '%v'", backendPort, eps.Ports[0].Port)
+	}
+}
+
+func TestEnsureDummyEndpointsliceIfNotExist(t *testing.T) {
+	lb := &lbv1.LoadBalancer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lb",
+			Namespace: "default",
+		},
+	}
+
+	existingEPS := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lb",
+			Namespace: "default",
+		},
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Addresses: []string{"test"},
+			},
+		},
+	}
+
+	existingEmptyEPS := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lb",
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name          string
+		existingObjs  []runtime.Object
+		expectCreated bool
+		expectUpdated bool
+		expectErr     bool
+	}{
+		{
+			name:          "EndpointSlice already exists in cache",
+			existingObjs:  []runtime.Object{existingEPS},
+			expectCreated: false,
+			expectErr:     false,
+		},
+		{
+			name:          "EndpointSlice does not exist, create successfully",
+			existingObjs:  []runtime.Object{},
+			expectCreated: true,
+			expectErr:     false,
+		},
+		{
+			name:          "EndpointSlice exists but with empty endpoints, update successfully",
+			existingObjs:  []runtime.Object{existingEmptyEPS},
+			expectUpdated: true,
+			expectErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset(tt.existingObjs...)
+
+			epsClient := fakeclients.EndpointSliceClient(func(namespace string) discoveryv1type.EndpointSliceInterface {
+				return fakeClient.DiscoveryV1().EndpointSlices(namespace)
+			})
+
+			epsCache := fakeclients.EndpointSliceCache(func(namespace string) discoveryv1type.EndpointSliceInterface {
+				return fakeClient.DiscoveryV1().EndpointSlices(namespace)
+			})
+
+			m := &Manager{
+				endpointSliceClient: epsClient,
+				endpointSliceCache:  epsCache,
+			}
+
+			err := m.ensureDummyEndpointSliceIfNotExist(lb)
+
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// Filter actions for 'create', 'update' verb specifically
+			var createActions []clientgotesting.Action
+			var updateActions []clientgotesting.Action
+			for _, action := range fakeClient.Actions() {
+				if action.GetVerb() == "create" {
+					createActions = append(createActions, action)
+				} else if action.GetVerb() == "update" {
+					updateActions = append(updateActions, action)
+				}
+			}
+
+			if tt.expectCreated && len(createActions) != 1 {
+				t.Fatalf("expected 1 'create' API action, got %d", len(createActions))
+			}
+			if tt.expectUpdated && len(updateActions) != 1 {
+				t.Fatalf("expected 1 'update' API action, got %d", len(updateActions))
 			}
 		})
 	}

--- a/pkg/utils/fakeclients/endpointslice.go
+++ b/pkg/utils/fakeclients/endpointslice.go
@@ -1,0 +1,84 @@
+package fakeclients
+
+import (
+	"context"
+
+	discoveryv1type "github.com/harvester/harvester-load-balancer/pkg/generated/clientset/versioned/typed/discovery.k8s.io/v1"
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	v1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+type EndpointSliceClient func(namespace string) discoveryv1type.EndpointSliceInterface
+
+func (c EndpointSliceClient) Create(endpointSlice *v1.EndpointSlice) (*v1.EndpointSlice, error) {
+	return c(endpointSlice.Namespace).Create(context.TODO(), endpointSlice, metav1.CreateOptions{})
+}
+
+func (c EndpointSliceClient) Update(endpointSlice *v1.EndpointSlice) (*v1.EndpointSlice, error) {
+	return c(endpointSlice.Namespace).Update(context.TODO(), endpointSlice, metav1.UpdateOptions{})
+}
+
+func (c EndpointSliceClient) UpdateStatus(_ *v1.EndpointSlice) (*v1.EndpointSlice, error) {
+	panic("implement me")
+}
+
+func (c EndpointSliceClient) Delete(namespace, name string, opts *metav1.DeleteOptions) error {
+	deleteOpts := metav1.DeleteOptions{}
+	if opts != nil {
+		deleteOpts = *opts
+	}
+	return c(namespace).Delete(context.TODO(), name, deleteOpts)
+}
+
+func (c EndpointSliceClient) Get(namespace, name string, opts metav1.GetOptions) (*v1.EndpointSlice, error) {
+	return c(namespace).Get(context.TODO(), name, opts)
+}
+
+func (c EndpointSliceClient) List(namespace string, opts metav1.ListOptions) (*v1.EndpointSliceList, error) {
+	return c(namespace).List(context.TODO(), opts)
+}
+
+func (c EndpointSliceClient) Watch(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	panic("implement me")
+}
+
+func (c EndpointSliceClient) Patch(namespace, name string, pt types.PatchType, data []byte, _ ...string) (result *v1.EndpointSlice, err error) {
+	return c(namespace).Patch(context.TODO(), name, pt, data, metav1.PatchOptions{})
+}
+
+func (c EndpointSliceClient) WithImpersonation(_ rest.ImpersonationConfig) (generic.ClientInterface[*v1.EndpointSlice, *v1.EndpointSliceList], error) {
+	panic("implement me")
+}
+
+type EndpointSliceCache func(namespace string) discoveryv1type.EndpointSliceInterface
+
+func (c EndpointSliceCache) Get(namespace, name string) (*v1.EndpointSlice, error) {
+	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c EndpointSliceCache) List(namespace string, selector labels.Selector) ([]*v1.EndpointSlice, error) {
+	list, err := c(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*v1.EndpointSlice, 0, len(list.Items))
+	for i := range list.Items {
+		result = append(result, &list.Items[i])
+	}
+	return result, nil
+}
+
+func (c EndpointSliceCache) AddIndexer(_ string, _ generic.Indexer[*v1.EndpointSlice]) {
+	panic("implement me")
+}
+
+func (c EndpointSliceCache) GetByIndex(_, _ string) ([]*v1.EndpointSlice, error) {
+	panic("implement me")
+}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

After kube-vip v1.2.* version, kube-vip only applies VIP after endpointslices is existing and endpoint is not empty. It creates a dead lock with current loadbalancer.

The existing cooperation between harvester and kube-vip before kube-vip v1.2.2

diagram-1

```
========================================================================================
             STANDARD FLOW: HARVESTER LOADBALANCER CONTROLLER & KUBE-VIP
========================================================================================

+------------------------------------+                 +---------------------+
| harvester-loadbalancer-controller |                 |      kube-vip       |
+------------------------------------+                 +---------------------+
                  |                                              |
                  | (1) Create LB Service                        |
                  |     (Set IP = 0.0.0.0)                       |
                  |--------------------------------------------->|
                  |                                              |
                  |                                              | (2) Perform DHCP &
                  |                                              |     assign real IP
                  |                                              |     (e.g., 10.0.0.100)
                  |                                              |
                  | <--- [ WAITING FOR REAL IP ASSIGNMENT ] -----|
                  |<---------------------------------------------|
                  |                                              |
                  | (2.1) Service IP updated!                    |
                  |       Controller unblocks & moves forward    |
                  v                                              v
                  |                                              |
                  |==== (3) Monitor Backend VMs =================|
                  |                                              |
                  +--+                                           |
                     |                                           |
                     v                                           |
         [ VM State Evaluation ]                                 |
                     |                                           |
        +------------+------------+                              |
        |                         |                              |
        v                         v                              |
 (3.1) No VM /               (3.2) VM has                        |
 Not Running /                    Real IP                        |
 No IP                            |                              |
        |                         |                              |
        v                         v                              |
+-------------------+     +-------------------+                  |
|  Add Dummy        |     | Drop Dummy        |                  |
|  Endpoint         |     | Endpoint          |                  |
+-------------------+     +-------------------+                  |
        |                         |                              |
        |                         v                              |
        |                 +-------------------+                  |
        |                 | Update Endpoint   |                  |
        |                 | with Real VM IP   |                  |
        |                 +-------------------+                  |
        |                         |                              |
        +------------+------------+                              |
                     |                                           |
                     v                                           |
        [ EndpointSlices Updated ]                               |
```

on kube-vip v1.2.2, the dead lock:

diagram-2
```
========================================================================================
                          DEADLOCK SCENARIO (kube-vip v1.2.*)
========================================================================================

+------------------------------------+                         +---------------------+
| harvester-loadbalancer-controller |                         |  kube-vip v1.2.*   |
+------------------------------------+                         +---------------------+
                  |                                                       |
                  | (1) Creates LB Service                                |
                  |     (Sets IP = 0.0.0.0)                               |
                  |------------------------------------------------------>|
                  |                                                       |
                  |                                                       |
  +---------------+---------------+                       +---------------+---------------+
  |   WAITING FOR REAL IP...      |                       |   WAITING FOR ENDPOINTS...    |
  |                               |                       |                               |
  | Controller WILL NOT create    |                       | kube-vip WILL NOT request     |
  | valid EndpointSlices (with    |                       | DHCP or update Service with   |
  | VM IPs) until Service receives|                       | real IP until EndpointSlice   |
  | a real IP.                    |                       | exists and is NOT empty.      |
  +---------------+---------------+                       +---------------+---------------+
                  |                                                       |
                  |                       X  DEADLOCK  X                  |
                  |  ===================================================  |
                  |  Controller waits for kube-vip to assign real IP...   |
                  |  kube-vip waits for Controller to populate endpoints..|
                  |  ===================================================  |
                  |                                                       |
                  | (Cannot proceed)                               (Cannot proceed)
                  v                                                       v
```


#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

diagram-3
```
========================================================================================
             SOLUTION: PARALLEL DUMMY ENDPOINTSLICE TO BYPASS DEADLOCK
========================================================================================

+------------------------------------+                         +---------------------+
| harvester-loadbalancer-controller |                         |   kube-vip v1.2.*   |
+------------------------------------+                         +---------------------+
                  |                                                       |
                  | (1) Create LB Service (IP = 0.0.0.0)                 |
                  |------------------------------------------------------>|
                  |                                                       |
                  | (1.1) IN PARALLEL:                                    |
                  |       Create Dummy EndpointSlice                      |
                  |       (Satisfies kube-vip's non-empty check)          |
                  |------------------------------------------------------>|
                  |                                                       |
                  |                                                       | (2) kube-vip sees non-empty
                  |                                                       |     EndpointSlice -> Performs DHCP
                  |                                                       |     & assigns real IP
                  |                                                       |
                  | <--- [ WAITING FOR REAL IP ASSIGNMENT ] --------------|
                  |<------------------------------------------------------|
                  |                                                       |
                  | (2.1) Service IP updated!                             |
                  |       Controller unblocks & moves forward             |
                  v                                                       v
                  |                                                       |
                  |==== (3) Monitor Backend VMs ==========================|
                  |                                                       |
                  +--+                                                    |
                     |                                                    |
                     v                                                    |
         [ VM State Evaluation ]                                          |
                     |                                                    |
        +------------+------------+                                       |
        |                         |                                       |
        v                         v                                       |
 (3.1) No VM /               (3.2) VM has                                 |
 Not Running /                    Real IP                                 |
 No IP                            |                                       |
        |                         |                                       |
        v                         v                                       |
+-------------------+     +-------------------+                           |
| Keep Dummy        |     | Drop Dummy        |                           |
| Endpoint          |     | Endpoint          |                           |
+-------------------+     +-------------------+                           |
        |                         |                                       |
        |                         v                                       |
        |                 +-------------------+                           |
        |                 | Update Endpoint   |                           |
        |                 | with Real VM IP   |                           |
        |                 +-------------------+                           |
        |                         |                                       |
        +------------+------------+                                       |
                     |                                                    |
                     v                                                    |
        [ EndpointSlices Updated ]                                        |
```


1. LB controller creates a dummy endpointslice when VM type service is created, to break the dead lock, then kube-vip will continue to update the VIP to service status, LB controller then follow to update VM IPs into endpointslice and finally move LB to ready status.

The LB shows following errors if any step is not met:

- No exernal IP, when LB can't get IP from IPPool, or kube-vip can't get VIP from DHCP via MAC-VLAN interface.
- No running backend servers, when LB can't select any
- Backend servers have no valid IP, when non of the backend VM has valid IP.



#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/11574

#### Test plan:
<!-- Describe the test plan by steps. -->

1. replace kube-vip image tag with v1.2.3;   create VM LB dhcp mode, without matching VM

<img width="2984" height="522" alt="image" src="https://github.com/user-attachments/assets/112c4317-ab84-46ff-94f2-88b55a3b295d" />

LB shows error `No running backend servers`,  but still gets the VIP, kube-vip also binds VIP.  And when VM is up, IP is available, the VIP could be accessed.

When backend VM is up and with IP

<img width="2744" height="264" alt="image" src="https://github.com/user-attachments/assets/5fb48219-311d-494b-8991-8ddb2b586b0e" />


<img width="2948" height="568" alt="image" src="https://github.com/user-attachments/assets/68d2c8dc-c94f-4d87-a33b-50b89b0d5dad" />

curl test on the service ip & port:

```
curl http://192.168.122.107:80
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
<title>Directory listing for /</title>
</head>
<body>
<h1>Directory listing for /</h1>
<hr>
<ul>
<li><a href="hello-world.txt">hello-world.txt</a></li>
</ul>
<hr>
</body>
</html>
```

backend server:

```
rancher@vm1:~/test$ python3 -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
192.168.122.153 - - [09/Sep/2026 08:23:28] "GET / HTTP/1.1" 200 -
```




When backend VM is off:

<img width="2624" height="292" alt="image" src="https://github.com/user-attachments/assets/4bf1e897-8f05-4b0b-b492-fc98288db0e2" />

<img width="2928" height="384" alt="image" src="https://github.com/user-attachments/assets/d2289a75-4005-421c-9809-9bd00698e16f" />

When backend VM is booting but IP is not poped up yet:

<img width="2632" height="334" alt="image" src="https://github.com/user-attachments/assets/b2c536c1-4ca0-44c5-85b9-aad9414999a1" />


When LB selector matches none VM:

<img width="2190" height="372" alt="image" src="https://github.com/user-attachments/assets/d11c8cc9-a50b-48d1-b1c4-0808282c7486" />


All the test results are same as original behavious with kube-vip v1.1.2.

The PR unlocks the dead lock but keep other process stable.

#### Additional documentation or context

log of kube-vip pod: two services (pool, dhcp) are created and removed

```
2026/09/09 08:08:44 INFO kube-vip.io version=v1.2.3 build=7ce55caffa2789b4165072bbef7c7d376000995e
...

2026/09/09 08:51:17 INFO new instance namespace=default service=lb-pool-1 addresses=[192.168.122.2] hostnames=[]
2026/09/09 08:51:17 INFO (svcs) adding VIP ip=192.168.122.2 interface=mgmt-br namespace=default name=lb-pool-1
2026/09/09 08:51:17 INFO watching provider=endpointslices service_name=lb-pool-1 namespace=default
2026/09/09 08:51:17 INFO (svcs) service function starting uid=6c545ef7-cbc0-4165-83c0-35ac3b463d96
2026/09/09 08:51:17 INFO successful add IP address=192.168.122.2
2026/09/09 08:51:17 INFO layer 2 broadcaster starting IP=192.168.122.2 device=mgmt-br
2026/09/09 08:51:17 INFO [ARP manager] inserting ARP/NDP instance name=192.168.122.2/32-mgmt-br
2026/09/09 08:51:17 INFO [service] service=lb-pool-1 namespace=default "synchronised in"=11ms
2026/09/09 08:51:17 INFO (svcs) service function done uid=6c545ef7-cbc0-4165-83c0-35ac3b463d96

2026/09/09 08:53:25 INFO new instance namespace=default service=lb-dhcp-1 addresses=[0.0.0.0] hostnames=[]
2026/09/09 08:53:25 INFO creating new macvlan interface for DHCP interface=vip-6d74f613
2026/09/09 08:53:25 INFO Generated mac address=00:00:6C:33:cf:17
2026/09/09 08:53:25 INFO new macvlan interface interface=vip-6d74f613 "hardware address"="\x00\x00l3\xcf\x17"
2026/09/09 08:53:25 ERROR [DHCP] unable to write rp_filter value=0 err="failed to open file: open /proc/sys/net/ipv4/conf/vip-6d74f613/rp_filter: read-only file system"
2026/09/09 08:53:29 INFO (svcs) adding VIP ip=192.168.122.125 interface=vip-6d74f613 namespace=default name=lb-dhcp-1
2026/09/09 08:53:29 INFO watching provider=endpointslices service_name=lb-dhcp-1 namespace=default
2026/09/09 08:53:29 INFO (svcs) service function starting uid=6d74f613-514c-47dc-95c4-e3b77aca3b17
2026/09/09 08:53:29 INFO successful add IP address=192.168.122.125
2026/09/09 08:53:29 INFO layer 2 broadcaster starting IP=192.168.122.125 device=vip-6d74f613
2026/09/09 08:53:29 INFO [ARP manager] inserting ARP/NDP instance name=192.168.122.125/32-vip-6d74f613
2026/09/09 08:53:29 INFO [service] service=lb-dhcp-1 namespace=default "synchronised in"=9ms
2026/09/09 08:53:29 INFO (svcs) service function done uid=6d74f613-514c-47dc-95c4-e3b77aca3b17


2026/09/09 08:53:55 INFO [endpoint watcher] stopping watching - endpoint object deleted provider=endpointslices "service name"=lb-pool-1 namespace=default
2026/09/09 08:53:55 INFO [ARP manager] removing ARP/NDP instance name=192.168.122.2/32-mgmt-br
2026/09/09 08:53:55 INFO Removed instance from manager uid=6c545ef7-cbc0-4165-83c0-35ac3b463d96 name=lb-pool-1 "remaining advertised services"=2
2026/09/09 08:53:55 WARN (svcs) The load balancer was deleted, cancelling context namespace=default name=lb-pool-1 uid=6c545ef7-cbc0-4165-83c0-35ac3b463d96
2026/09/09 08:53:55 INFO (svcs) deleted "service name"=lb-pool-1 namespace=default
2026/09/09 08:53:55 INFO [LOADBALANCER] Stopping load balancers name=default/lb-pool-1
2026/09/09 08:53:55 INFO [VIP] Deleting VIP ip=192.168.122.2


2026/09/09 08:54:01 INFO [endpoint watcher] stopping watching - endpoint object deleted provider=endpointslices "service name"=lb-dhcp-1 namespace=default
2026/09/09 08:54:01 INFO [ARP manager] removing ARP/NDP instance name=192.168.122.125/32-vip-6d74f613
2026/09/09 08:54:01 INFO [DHCPv4] release lease="&{Offer:DHCPv4(xid=0xdeaf9f1c hwaddr=00:00:6c:33:cf:17 msg_type=OFFER, your_ip=192.168.122.125, server_ip=192.168.122.1) ACK:DHCPv4(xid=0xdeaf9f1c hwaddr=00:00:6c:33:cf:17 msg_type=ACK, your_ip=192.168.122.125, server_ip=192.168.122.1) CreationTime:2026-09-09 08:53:29.19476987 +0000 UTC m=+2685.167973473}"
2026/09/09 08:54:01 INFO [LOADBALANCER] Stopping load balancers name=default/lb-dhcp-1
2026/09/09 08:54:01 INFO [VIP] Deleting VIP ip=192.168.122.125
2026/09/09 08:54:01 INFO Removed instance from manager uid=6d74f613-514c-47dc-95c4-e3b77aca3b17 name=lb-dhcp-1 "remaining advertised services"=1
2026/09/09 08:54:01 WARN (svcs) The load balancer was deleted, cancelling context namespace=default name=lb-dhcp-1 uid=6d74f613-514c-47dc-95c4-e3b77aca3b17
2026/09/09 08:54:01 INFO (svcs) deleted "service name"=lb-dhcp-1 namespace=default
```